### PR TITLE
fix: manufacturer name in bold

### DIFF
--- a/src/main/resources/schemas/CoA/v1.1.0/stylesheet.xsl
+++ b/src/main/resources/schemas/CoA/v1.1.0/stylesheet.xsl
@@ -49,10 +49,29 @@
                           <fo:external-graphic fox:alt-text="Company Logo" src="{Root/Certificate/Logo}" content-height="48px" height="48px" />
                         </fo:block>
                       </fo:table-cell>
-                      <xsl:call-template name="PartyInfo">
-                        <xsl:with-param name="title" select="$Parties/Manufacturer/Value" />
-                        <xsl:with-param name="party" select="$Parties/Manufacturer" />
-                      </xsl:call-template>
+                      <fo:table-cell>
+                        <fo:block padding-bottom="4pt" font-weight="bold">
+                          <xsl:value-of select="$Parties/Manufacturer/Name" />
+                        </fo:block>
+                        <fo:block>
+                          <xsl:value-of select="$Parties/Manufacturer/Street" />
+                        </fo:block>
+                        <xsl:for-each select="$Parties/Manufacturer/Streets/Street">
+                          <fo:block>
+                            <xsl:value-of select="." />
+                          </fo:block>
+                        </xsl:for-each>
+                        <fo:block>
+                          <xsl:value-of select="concat($Parties/Manufacturer/ZipCode, ' ', $Parties/Manufacturer/City, ', ', $Parties/Manufacturer/Country)" />
+                        </fo:block>
+                        <fo:block>
+                          <fo:basic-link external-destination="{concat('mailto:', $Parties/Manufacturer/Email)}">
+                            <fo:inline text-decoration="underline">
+                              <xsl:value-of select="$Parties/Manufacturer/Email" />
+                            </fo:inline>
+                          </fo:basic-link>
+                        </fo:block>
+                      </fo:table-cell>
                     </fo:table-row>
                     <fo:table-row>
                       <xsl:call-template name="PartyInfo">
@@ -89,18 +108,18 @@
                         <xsl:with-param name="title" select="$i18n/Certificate/Customer" />
                         <xsl:with-param name="party" select="$Parties/Customer" />
                       </xsl:call-template>
-                    <xsl:if test="exists($Parties/Receiver)">
-                      <xsl:call-template name="PartyInfo">
-                        <xsl:with-param name="title" select="$i18n/Certificate/Receiver" />
-                        <xsl:with-param name="party" select="$Parties/Receiver" />
-                      </xsl:call-template>
-                    </xsl:if>
-                    <xsl:if test="exists($Parties/GoodsReceiver)">
-                      <xsl:call-template name="PartyInfo">
-                        <xsl:with-param name="title" select="$i18n/Certificate/GoodsReceiver" />
-                        <xsl:with-param name="party" select="$Parties/GoodsReceiver" />
-                      </xsl:call-template>
-                    </xsl:if>
+                      <xsl:if test="exists($Parties/Receiver)">
+                        <xsl:call-template name="PartyInfo">
+                          <xsl:with-param name="title" select="$i18n/Certificate/Receiver" />
+                          <xsl:with-param name="party" select="$Parties/Receiver" />
+                        </xsl:call-template>
+                      </xsl:if>
+                      <xsl:if test="exists($Parties/GoodsReceiver)">
+                        <xsl:call-template name="PartyInfo">
+                          <xsl:with-param name="title" select="$i18n/Certificate/GoodsReceiver" />
+                          <xsl:with-param name="party" select="$Parties/GoodsReceiver" />
+                        </xsl:call-template>
+                      </xsl:if>
                     </fo:table-row>
                   </fo:table-body>
                 </xsl:otherwise>


### PR DESCRIPTION
# Description
fixes #15 
This PR fixes the manufacturer name in CoA schema type, which sold be in bold.

before:
<img width="894" alt="image" src="https://github.com/material-identity/schemas/assets/111302980/1fe6d788-69da-47d2-9b67-74b157dd1630">

after:
<img width="794" alt="image" src="https://github.com/material-identity/schemas/assets/111302980/5195bd1f-5a66-4625-b13b-1cf69c1841d1">


# For Reviewer
Check for obvious mistakes or oversights