### PR TITLE
feat: update attachment code to be pdf-3a compliant

### DIFF
--- a/src/main/java/com/materialidentity/schemaservice/AttachmentManager.java
+++ b/src/main/java/com/materialidentity/schemaservice/AttachmentManager.java
@@ -7,8 +7,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
 import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
@@ -33,11 +38,22 @@ public class AttachmentManager {
     PDDocument document = Loader.loadPDF(pdfData);
     PDComplexFileSpecification fs = new PDComplexFileSpecification();
     fs.setFile(fileName);
+    fs.setFileUnicode(fileName);
 
     byte[] contentBytes = contentString.getBytes(StandardCharsets.UTF_8);
 
     InputStream is = new ByteArrayInputStream(contentBytes);
-    fs.setEmbeddedFile(new PDEmbeddedFile(document, is));
+    PDEmbeddedFile embeddedFile = new PDEmbeddedFile(document, is);
+    embeddedFile.setSubtype("application/json");
+    fs.setEmbeddedFile(embeddedFile);
+
+    COSDictionary dict = fs.getCOSObject();
+    dict.setName("AFRelationship", "Alternative");
+
+    PDDocumentCatalog catalog = document.getDocumentCatalog();
+    COSArray cosArray = new COSArray();
+    cosArray.add(fs.getCOSObject());
+    catalog.getCOSObject().setItem(COSName.AF, cosArray);
 
     PDEmbeddedFilesNameTreeNode efTree = new PDEmbeddedFilesNameTreeNode();
     Map<String, PDComplexFileSpecification> efMap = new HashMap<>();
@@ -49,7 +65,6 @@ public class AttachmentManager {
     names.setEmbeddedFiles(efTree);
     document.getDocumentCatalog().setNames(names);
 
-    // Save the document with the attachment to a new ByteArrayOutputStream
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     document.save(output);
     return output.toByteArray();


### PR DESCRIPTION
# Description
This PR addresses the failed test results from running verapdf cli validation tool.

# For Reviewer
General code review

# Context
Before the code updates, when running verapdf validation cli tool, this is the resulting report:
```ssh
/Users/andrefernandes/Downloads/52b074ae-9d43-449f-90e5-8c716c0e1991.pdf

The additional information provided for associated files as well as the usage requirements for associated files indicate the relationship between the embedded file and the PDF document or the part of the PDF document with which it is associated

---

Failed:
2 occurrences

Error Details:

- CosFileSpecification
  - isAssociatedFile == true
    - root/EmbeddedFiles[0]
      - The file specification dictionary for an embedded file is not associated with the PDF document or any of its parts.
    - root/indirectObjects[252](480 0)/directObject[0]
      - The file specification dictionary for an embedded file is not associated with the PDF document or any of its parts.

---

Additional Errors:

- The MIME type of an embedded file, or a subset of a file, shall be specified using the Subtype key of the file specification dictionary. If the MIME type is not known, the "application/octet-stream" shall be used
  - EmbeddedFile Subtype != null && /^[-\w+\.]+\/[-\w+\.]+$/.test(Subtype)
    - root/EmbeddedFiles[0]/EF[0]
      - MIME type null of an embedded file is missing or invalid.
    - root/indirectObjects[252](480 0)/directObject[0]/EF[0]
      - MIME type null of an embedded file is missing or invalid.

- The file specification dictionary for an embedded file shall contain the F and UF keys
  - CosFileSpecification containsEF == false || (F != null && UF != null)
    - root/EmbeddedFiles[0]
      - The file specification dictionary for an embedded file does not contain either F or UF key (F = certificate.json, UF = null).
    - root/indirectObjects[252](480 0)/directObject[0]
      - The file specification dictionary for an embedded file does not contain either F or UF key (F = certificate.json, UF = null).

- The file specification dictionary shall contain key AFRelationship of type Name identifying the relationship between the embedded file and the content of the document
  - CosFileSpecification AFRelationship != null
    - root/EmbeddedFiles[0]
      - The file specification dictionary for an embedded file does not contain the AFRelationship key or it has invalid value type.
    - root/indirectObjects[252](480 0)/directObject[0]
      - The file specification dictionary for an embedded file does not contain the AFRelationship key or it has invalid value type.

---

00:00:00.160
1 0 0
00:00:00.174

```

after performing the necessary updates in AttachmentManager.java file, all the compliance tests pass:
<img width="590" alt="image" src="https://github.com/material-identity/schemas/assets/111302980/36697867-a9d0-4ae2-9e1a-e47c7fcde1b2">
