### PR TITLE
refactor: modify file-structure

### DIFF
--- a/.github/workflows/schema-cdn.yml
+++ b/.github/workflows/schema-cdn.yml
@@ -25,13 +25,29 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secret.AWS_ACCOUNT_ID }}:role/GITHUB_ACTION
           role-session-name: githubactions
-          aws-region: eu-north-1${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Sync Files to S3
         run: |
-          aws s3 sync . s3://schema-cdn-service-bucket \
-            --exclude "*" \
-            --include "schemas/**/schema.json" \
+          # Create a temporary directory for transformed files
+          mkdir -p transformed
+          
+          # Find all schema.json files and create transformed copies
+          find schemas -name schema.json | while read file; do
+            # Extract components from path (e.g., schemas/Forestry/v0.0.1/schema.json)
+            domain=$(echo "$file" | cut -d'/' -f2 | tr '[:upper:]' '[:lower:]')
+            version=$(echo "$file" | cut -d'/' -f3)
+            
+            # Create new path with transformed structure
+            new_path="transformed/${domain}-schemas/${version}/schema.json"
+            
+            # Create directory structure and copy file
+            mkdir -p "$(dirname "$new_path")"
+            cp "$file" "$new_path"
+          done
+          
+          # Sync transformed directory to S3
+          aws s3 sync transformed/ s3://schema-cdn-service-bucket \
             --delete
 
       - name: Invalidate CloudFront Cache


### PR DESCRIPTION
This change modifies the GitHub Action to modify the file-structure of the S3 Bucket. Instead of mirroring the structure of the GitHub Repo, the action now:
1. Puts the schema type (for example "forestry" as the top level
2. Ensures all directory names are lowercase
3. adds the `-schemas` suffix to the schema type directory name.

Hence: instead of storing a file as `/schemas/Forestry/v0.0.1/schema.json` we now store it as `/forestry-schemas/v0.0.1/schemas.json`

It also fixes a small typo from the previous version to ensure we fetch values from Repository secrets.