### PR TITLE
fix: allow filename of attached json to be passed in via param

### DIFF
--- a/src/main/java/com/materialidentity/schemaservice/AttachmentManager.java
+++ b/src/main/java/com/materialidentity/schemaservice/AttachmentManager.java
@@ -19,15 +19,18 @@ import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
 
+
+import static com.materialidentity.schemaservice.config.SchemaControllerConstants.DEFAULT_PDF_ATTACHMENT_CERT_FILE_EXTENSION;
+
 public class AttachmentManager {
 
   private final String contentString;
-  private final String fileName;
+  private String filename;
   private final Boolean attachJson;
 
-  public AttachmentManager(String contentString, String fileName, Boolean attachJson) {
+  public AttachmentManager(String contentString, String filename, Boolean attachJson) {
     this.contentString = contentString;
-    this.fileName = fileName;
+    this.filename = filename;
     this.attachJson = attachJson;
   }
 
@@ -37,8 +40,11 @@ public class AttachmentManager {
     }
     PDDocument document = Loader.loadPDF(pdfData);
     PDComplexFileSpecification fs = new PDComplexFileSpecification();
-    fs.setFile(fileName);
-    fs.setFileUnicode(fileName);
+    if (!filename.endsWith(DEFAULT_PDF_ATTACHMENT_CERT_FILE_EXTENSION)) {
+      filename += DEFAULT_PDF_ATTACHMENT_CERT_FILE_EXTENSION;
+    }
+    fs.setFile(filename);
+    fs.setFileUnicode(filename);
 
     byte[] contentBytes = contentString.getBytes(StandardCharsets.UTF_8);
 
@@ -57,7 +63,7 @@ public class AttachmentManager {
 
     PDEmbeddedFilesNameTreeNode efTree = new PDEmbeddedFilesNameTreeNode();
     Map<String, PDComplexFileSpecification> efMap = new HashMap<>();
-    efMap.put(fileName, fs);
+    efMap.put(filename, fs);
     efTree.setNames(efMap);
 
     PDDocumentNameDictionary names = new PDDocumentNameDictionary(

--- a/src/main/java/com/materialidentity/schemaservice/config/EndpointParamConstants.java
+++ b/src/main/java/com/materialidentity/schemaservice/config/EndpointParamConstants.java
@@ -2,9 +2,7 @@ package com.materialidentity.schemaservice.config;
 
 public final class EndpointParamConstants {
     // endpoint parameters constants
-    public static final String SCHEMA_TYPE_PARAM = "schemaType";
-    public static final String SCHEMA_VERSION_PARAM = "schemaVersion";
-    public static final String LANGUAGES_PARAM = "languages";
+    public static final String JSON_FILENAME = "filename";
     public static final String ATTACH_JSON = "attachJson";
 
     private EndpointParamConstants() {

--- a/src/main/java/com/materialidentity/schemaservice/config/SchemaControllerConstants.java
+++ b/src/main/java/com/materialidentity/schemaservice/config/SchemaControllerConstants.java
@@ -5,7 +5,8 @@ public final class SchemaControllerConstants {
     public static final String SCHEMAS_FOLDER_NAME = "schemas";
     public static final String JSON_TRANSLATIONS_FILE_NAME_PATTERN = "translations*.json";
     public static final String XSLT_FILE_NAME = "stylesheet.xsl";
-    public static final String PDF_ATTACHMENT_CERT_FILE_NAME = "dmp.json";
+    public static final String DEFAULT_PDF_ATTACHMENT_CERT_FILE_NAME = "dmp.json";
+    public static final String DEFAULT_PDF_ATTACHMENT_CERT_FILE_EXTENSION = ".json";
     public static final String PDF_RENDERED_OUTPUT_FILE_NAME = "output.pdf";
 
     // validate endpoint constants

--- a/src/main/java/com/materialidentity/schemaservice/controller/SchemaController.java
+++ b/src/main/java/com/materialidentity/schemaservice/controller/SchemaController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import javax.xml.transform.TransformerException;
 
+import com.materialidentity.schemaservice.config.SchemaControllerConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +40,8 @@ public class SchemaController {
     @Operation(summary = "Render a JSON DMP as a PDF")
     public ResponseEntity<byte[]> render(
             @RequestParam(value = EndpointParamConstants.ATTACH_JSON, defaultValue = "true") Boolean attachJson,
+            @RequestParam(value = EndpointParamConstants.JSON_FILENAME, defaultValue = SchemaControllerConstants.DEFAULT_PDF_ATTACHMENT_CERT_FILE_NAME) String filename,
             @RequestBody JsonNode dmp) throws TransformerException, IOException, SAXException {
-        return schemasService.renderPdf(attachJson, dmp);
+        return schemasService.renderPdf(attachJson, dmp, filename);
     }
 }

--- a/src/main/java/com/materialidentity/schemaservice/service/SchemasService.java
+++ b/src/main/java/com/materialidentity/schemaservice/service/SchemasService.java
@@ -10,6 +10,6 @@ import org.xml.sax.SAXException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public interface SchemasService {
-        ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate)
+        ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate, String filename)
                         throws IOException, TransformerException, SAXException;
 }

--- a/src/main/java/com/materialidentity/schemaservice/service/SchemasServiceImpl.java
+++ b/src/main/java/com/materialidentity/schemaservice/service/SchemasServiceImpl.java
@@ -160,15 +160,15 @@ public class SchemasServiceImpl implements SchemasService {
     }
 
     @Override
-    public ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate)
+    public ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate, String filename)
             throws IOException, TransformerException, SAXException {
         String[] languages = extractLanguages(certificate);
         String[] encodedData = extractPdfData(certificate);
         String[] dataFromS3 = extractPdfDataFromS3(certificate);
         String schemaType = extractCertificateType(certificate);
         String schemaVersion = extractCertificateVersion(certificate);
-        logger.info("Rendering certificate type: {}, version: {}, languages: {}, attachJson: {}", schemaType,
-                schemaVersion, languages, attachJson);
+        logger.info("Rendering certificate type: {}, version: {}, languages: {}, attachJson: {}, filename: {}", schemaType,
+                schemaVersion, languages, attachJson, filename);
 
         // TODO: throw error if language is not supported
         validateSchemaTypeAndVersion(schemaType, schemaVersion);
@@ -193,7 +193,7 @@ public class SchemasServiceImpl implements SchemasService {
                 .withTranslations(new TranslationLoader(translationsPattern, languages))
                 .withAttachment(
                         new AttachmentManager(certificateJson,
-                                SchemaControllerConstants.PDF_ATTACHMENT_CERT_FILE_NAME,
+                                filename,
                                 attachJson));
 
         if (encodedData != null || dataFromS3 != null) {

--- a/src/test/java/com/materialidentity/schemaservice/RenderTest.java
+++ b/src/test/java/com/materialidentity/schemaservice/RenderTest.java
@@ -71,7 +71,7 @@ class RenderTest {
 					try {
 						assertPdfContentEquals(expectedPdfContent, responseBody);
 						assertPdfContainsEmbeddedFile(responseBody,
-								SchemaControllerConstants.PDF_ATTACHMENT_CERT_FILE_NAME,
+								SchemaControllerConstants.DEFAULT_PDF_ATTACHMENT_CERT_FILE_NAME,
 								jsonContent.getBytes(), true);
 					} catch (Exception e) {
 						throw new RuntimeException("PDF comparison failed", e);
@@ -105,7 +105,7 @@ class RenderTest {
 					try {
 						assertPdfContentEquals(expectedPdfContent, responseBody);
 						assertPdfContainsEmbeddedFile(responseBody,
-								SchemaControllerConstants.PDF_ATTACHMENT_CERT_FILE_NAME, jsonContent.getBytes(), false);
+								SchemaControllerConstants.DEFAULT_PDF_ATTACHMENT_CERT_FILE_NAME, jsonContent.getBytes(), false);
 					} catch (Exception e) {
 						throw new RuntimeException("PDF comparison failed", e);
 					}
@@ -138,7 +138,7 @@ class RenderTest {
 					try {
 						assertPdfContentEquals(expectedPdfContent, responseBody);
 						assertPdfContainsEmbeddedFile(responseBody,
-								SchemaControllerConstants.PDF_ATTACHMENT_CERT_FILE_NAME, jsonContent.getBytes(), false);
+								SchemaControllerConstants.DEFAULT_PDF_ATTACHMENT_CERT_FILE_NAME, jsonContent.getBytes(), false);
 					} catch (Exception e) {
 						throw new RuntimeException("PDF comparison failed", e);
 					}


### PR DESCRIPTION
This fixes a regression introduced along with the new schema service rendering where the name of the attached json was set to `dmp.json` instead of the previous version which contained information on the seller. This PR adds the functionality to allow the filename to be passed in via an optional param on the render endpoint.