### PR TITLE
ci: emergency fix for forestry-source-schemas

### DIFF
--- a/.github/workflows/schema-cdn.yml
+++ b/.github/workflows/schema-cdn.yml
@@ -39,6 +39,11 @@ jobs:
             domain=$(echo "$file" | cut -d'/' -f2 | tr '[:upper:]' '[:lower:]')
             version=$(echo "$file" | cut -d'/' -f3)
             
+            # TODO: replace this with a proper fix
+            if [ "$domain" = "forestrysource" ]; then
+              domain="forestry-source"
+            fi
+
             # Create new path with transformed structure
             new_path="transformed/${domain}-schemas/${version}/schema.json"
             


### PR DESCRIPTION
ForestrySource should be available in schemas-cdn as `forestry-source-schemas`, but is instead uploaded as `forestrysource-schemas`. This is a quick emergency fix and should be updated ASAP.