### PR TITLE
Added 404 file generation

### DIFF
--- a/.github/workflows/schema-cdn.yml
+++ b/.github/workflows/schema-cdn.yml
@@ -32,6 +32,9 @@ jobs:
         run: |
           # Create a temporary directory for transformed files
           mkdir -p transformed
+
+          # Create 404.txt file in the root of transformed directory
+          echo "Not Found" > transformed/404.txt
           
           # Find all schema.json files and create transformed copies
           find schemas -name schema.json | while read file; do


### PR DESCRIPTION
Our schema CDN service only responds with a 404 Error if an appropriate file is available. Since every commit resets of our S3 Bucket, this modification generates the necessary file automatically.