### PR TITLE
fix: fixed regex to match review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,18 @@
     },
     "SPRING_PROFILES_ACTIVE": {
       "required": true
-    }
+    },
+    "SCHEMAS_PRIVATE_S3_BUCKET_NAME": {
+      "required": true
+    },
+    "SCHEMAS_PRIVATE_AWS_ACCESS_KEY_ID": {
+      "required": true
+    },
+    "SCHEMAS_PRIVATE_AWS_SECRET_ACCESS_KEY": {
+      "required": true
+    },
+    "SCHEMAS_PRIVATE_AWS_REGION": {},
+      "required": true
   },
   "stack": "heroku-24",
   "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -1,0 +1,12 @@
+{
+  "name": "Schemas service app",
+  "description": "This app provides public and private schemas.",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs.git"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-java.git"
+    }
+  ]
+}

--- a/ui/src/app/schema.service.ts
+++ b/ui/src/app/schema.service.ts
@@ -12,7 +12,7 @@ export class SchemaService {
     "https://schemas-service.s1seven.com"
   ];
   // Regular expressions for dynamic server URL matching for Heroku review apps
-  private readonly trustedServerPattern = /^https:\/\/s1-schemas[a-zA-Z0-9-]+\.herokuapp\.com[\/]?$/;
+  private readonly trustedServerPattern = /^https:\/\/s1-schemas-pr-[0-9]+\.herokuapp\.com[\/]?$/;
 
   constructor() {}
 

--- a/ui/src/app/schema.service.ts
+++ b/ui/src/app/schema.service.ts
@@ -11,11 +11,8 @@ export class SchemaService {
     "https://schemas-service.staging.s1seven.com",
     "https://schemas-service.s1seven.com"
   ];
-
-  // Regular expressions for dynamic server URL matching
-  private readonly trustedServerPatterns = [
-    /^https:\/\/s1-schemas-.*\.herokuapp\.com$/  // Matches all Heroku review apps
-  ];
+  // Regular expressions for dynamic server URL matching for Heroku review apps
+  private readonly trustedServerPattern = /^https:\/\/s1-schemas(?:-service)?-[a-zA-Z0-9-]+\.herokuapp\.com[\/]?$/;
 
   constructor() {}
 
@@ -60,11 +57,12 @@ export class SchemaService {
         return url;
       }
 
-      // Check if the URL matches any of the dynamic patterns
-      if (this.trustedServerPatterns.some(pattern => pattern.test(url))) {
+      // Check if the URL matches the dynamic pattern
+      if (this.trustedServerPattern.test(url)) {
         return url;
       }
 
+    console.error(`Error: Couldn't find matching allowed url for ${baseUrl}`)
     return devUrl;
     }
     catch (e) {

--- a/ui/src/app/schema.service.ts
+++ b/ui/src/app/schema.service.ts
@@ -12,7 +12,7 @@ export class SchemaService {
     "https://schemas-service.s1seven.com"
   ];
   // Regular expressions for dynamic server URL matching for Heroku review apps
-  private readonly trustedServerPattern = /^https:\/\/s1-schemas(?:-service)?-[a-zA-Z0-9-]+\.herokuapp\.com[\/]?$/;
+  private readonly trustedServerPattern = /^https:\/\/s1-schemas[a-zA-Z0-9-]+\.herokuapp\.com[\/]?$/;
 
   constructor() {}
 


### PR DESCRIPTION
## Description
Review apps were still using development serverUrl, because their origin was not recognized with the existing pattern.

## Changes
1. Changed regex to match review apps urls
2. Logging origin url in case of error
## Testing
- [X] Manual testing steps:
 1. Tested using script to match some url examples with this regex

## Documentation

- [ ] I have updated the documentation accordingly.
- [X] No documentation update is required.

## Checklist

Please complete the following checklist before submitting the pull request:

  - [X] My code follows the project's coding style guidelines.
  - [X] I have performed a self-review of my code.
  - [X] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [X] My changes generate no new warnings or errors.
  - [ ] I have added tests that prove my fix is effective or that my feature works.
  - [X] New and existing unit tests pass locally with my changes.
  - [X] Any dependent changes have been merged and published in downstream modules.
