### PR TITLE
Removed "null" type from Unit

### DIFF
--- a/schemas/EN10168/v0.5.0/schema.json
+++ b/schemas/EN10168/v0.5.0/schema.json
@@ -214,14 +214,14 @@
         "Unit": {
           "description": "The unit of measurement (%, ppm, or other unit).",
           "type": "string",
-          "enum": ["%", "ppm", null]
+          "enum": ["%", "ppm"]
         },
         "Formula": {
           "description": "For calculated values (e.g., F1, F2, F3), this field can provide the formula definition",
           "type": "string"
         }
       },
-      "required": ["Symbol", "Actual", "Unit"],
+      "required": ["Symbol", "Actual"],
       "additionalProperties": false
     },
     "Measurement": {

--- a/schemas/EN10168/v0.5.0/schema.json
+++ b/schemas/EN10168/v0.5.0/schema.json
@@ -213,7 +213,7 @@
         },
         "Unit": {
           "description": "The unit of measurement (%, ppm, or other unit).",
-          "type": ["string", "null"],
+          "type": "string",
           "enum": ["%", "ppm", null]
         },
         "Formula": {

--- a/test/fixtures/EN10168/v0.5.0/valid_certificate_3.json
+++ b/test/fixtures/EN10168/v0.5.0/valid_certificate_3.json
@@ -256,8 +256,7 @@
             "Value": "0.400",
             "Operator": "<="
           },
-          "Symbol": "CEV",
-          "Unit": null
+          "Symbol": "CEV"
         }
       },
       "OtherMechanicalTests": {

--- a/test/fixtures/EN10168/v0.5.0/valid_certificate_4.json
+++ b/test/fixtures/EN10168/v0.5.0/valid_certificate_4.json
@@ -196,7 +196,6 @@
             "Value": "0.300"
           },
             "Symbol": "F1",
-            "Unit": null,
             "Formula": "F1 = C + Al"
           },
           "C88": {
@@ -204,7 +203,6 @@
             "Value": "0.0000"
           },
             "Symbol": "F2",
-            "Unit": null,
             "Formula": "F2= F1/Ni"
           },
           "C89": {
@@ -212,7 +210,6 @@
             "Value": "0.3227"
           },
             "Symbol": "F3",
-            "Unit": null,
             "Formula": "F3 = F1 + F2"
           }
         },


### PR DESCRIPTION
## Description

Some type generators, as for example the one for SAP, cannot handle type arrays. + it's unnecessary to extra mention null value as type, as the Unit is not "required"

## Related Issues

No official known issues yet, occurred while testing the type generator in SAP

## Changes

Removed "null" type for the Chemical Composition Unit

