### PR TITLE
Add concession request schema support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ schemas/TKR/*
 schemas/Bluemint/*
 test/fixtures/TKR/*
 test/fixtures/Bluemint/*
+test/fixtures/HKM/*

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ tmp/
 # schema-private files from S3Bucket
 schemas/TKR/*
 schemas/Bluemint/*
+schemas/HKM/*
 test/fixtures/TKR/*
 test/fixtures/Bluemint/*
 test/fixtures/HKM/*
+

--- a/src/main/java/com/materialidentity/schemaservice/config/SchemasAndVersions.java
+++ b/src/main/java/com/materialidentity/schemaservice/config/SchemasAndVersions.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class SchemasAndVersions {
   public enum SchemaTypes {
-    EN10168, CoA, TKR, Forestry, ForestrySource, Metals, Bluemint
+    EN10168, CoA, TKR, Forestry, ForestrySource, Metals, Bluemint, HKM
   }
 
   public static final Map<SchemaTypes, List<String>> supportedSchemas = Map.of(
@@ -15,5 +15,6 @@ public class SchemasAndVersions {
       SchemaTypes.Forestry, List.of("v0.0.1"),
       SchemaTypes.ForestrySource, List.of("v0.0.1"),
       SchemaTypes.Metals, List.of("v0.0.1"),
-      SchemaTypes.Bluemint, List.of("v1.0.0"));
+      SchemaTypes.Bluemint, List.of("v1.0.0"),
+      SchemaTypes.HKM, List.of("v1.0.0"));
 }

--- a/src/main/java/com/materialidentity/schemaservice/service/SchemasServiceImpl.java
+++ b/src/main/java/com/materialidentity/schemaservice/service/SchemasServiceImpl.java
@@ -53,6 +53,7 @@ public class SchemasServiceImpl implements SchemasService {
         certificateTypeMap.put("forestry-source", "ForestrySource");
         certificateTypeMap.put("metals", "Metals");
         certificateTypeMap.put("bluemint", "Bluemint");
+        certificateTypeMap.put("hkm", "HKM");
     }
 
     public static String[] extractLanguages(JsonNode jsonContent) {
@@ -69,6 +70,9 @@ public class SchemasServiceImpl implements SchemasService {
                 .filter(Objects::nonNull)
                 .or(() -> Optional.ofNullable(jsonContent.get("DigitalMaterialPassport"))
                         .map(passportNode -> passportNode.get("Languages"))
+                        .filter(Objects::nonNull))
+                .or(() -> Optional.ofNullable(jsonContent.get("ConcessionRequest"))
+                        .map(concessionNode -> concessionNode.get("Languages"))
                         .filter(Objects::nonNull))
                 .filter(JsonNode::isArray)
                 .map(languagesNode -> {

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -15,6 +15,7 @@ const fixtureVersions = {
   "E-CoC": ['v1.0.0'],
   Bluemint: ['v1.0.0'],
   Metals: ['v0.0.1'],
+  HKM: ['v1.0.0'],
 }
 
 function getCertPaths() {


### PR DESCRIPTION
## Summary
- Add concession request schema type support to the schema service
- Update Java configuration to handle concession request certificate format
- Enhance language extraction logic for concession request ConcessionRequest.Languages structure
- Add concession request to .gitignore for private schema file management

## Test plan
- [ ] Verify concession request schema type is recognized in Java enums
- [ ] Test language extraction from concession request certificate format
- [ ] Confirm certificate type mapping works for concession request documents
- [ ] Validate .gitignore correctly excludes concession request private files