### PR TITLE
fix: security vulnerability updates (round 2)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, java-kotlin, javascript-typescript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up JDK 21
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2209,6 +2209,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4240,9 +4253,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "dev": true,
       "funding": [
         {
@@ -4256,9 +4269,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "dev": true,
       "funding": [
         {
@@ -4268,9 +4281,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5952,9 +5966,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "dev": true,
       "funding": [
         {
@@ -6473,9 +6487,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4351,9 +4351,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prettier": "^3.3.1"
   },
   "overrides": {
-    "fast-xml-parser": "^5.5.6"
+    "fast-xml-parser": "^5.5.6",
+    "follow-redirects": "^1.16.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier": "^3.3.1"
   },
   "overrides": {
-    "fast-xml-parser": "^5.5.6",
+    "fast-xml-parser": "^5.7.0",
     "follow-redirects": "^1.16.0"
   },
   "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -134,17 +134,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/materialidentity/schemaservice/CommandLineFoManager.java
+++ b/src/main/java/com/materialidentity/schemaservice/CommandLineFoManager.java
@@ -96,7 +96,11 @@ public class CommandLineFoManager {
             Source src = new StreamSource(new StringReader(xslFoInput));
             Result res = new SAXResult(fop.getDefaultHandler());
 
-            transformer.transform(src, res);
+            try {
+                transformer.transform(src, res);
+            } catch (RuntimeException e) {
+                throw new IOException(FoManager.getPdfGenerationErrorMessage(e), e);
+            }
 
             return outStream.toByteArray();
         }

--- a/src/main/java/com/materialidentity/schemaservice/EmbedManager.java
+++ b/src/main/java/com/materialidentity/schemaservice/EmbedManager.java
@@ -37,7 +37,8 @@ public class EmbedManager {
     try {
       PDFMergerUtility merger = new PDFMergerUtility();
 
-      for (String base64String : this.base64Data) {
+      for (int i = 0; i < this.base64Data.length; i++) {
+        String base64String = this.base64Data[i];
         String[] parts = base64String.split(",");
         String base64Part;
         if (parts.length > 1) {
@@ -46,9 +47,23 @@ public class EmbedManager {
           base64Part = parts[0].trim();
         }
 
-        byte[] decodedData = Base64.getDecoder().decode(base64Part);
+        byte[] decodedData;
+        try {
+          decodedData = Base64.getDecoder().decode(base64Part);
+        } catch (IllegalArgumentException e) {
+          throw new IOException(
+              "Embedded PDF attachment at position " + (i + 1) + " contains invalid base64 data. "
+                  + "Please check that the base64-encoded PDF is complete and correctly encoded.",
+              e);
+        }
+
         try (PDDocument embedDocument = Loader.loadPDF(decodedData)) {
           merger.appendDocument(originalDocument, embedDocument);
+        } catch (IOException e) {
+          throw new IOException(
+              "Embedded PDF attachment at position " + (i + 1) + " is corrupt or not a valid PDF. "
+                  + "Please check that the embedded document is a valid PDF file.",
+              e);
         }
       }
 
@@ -68,11 +83,26 @@ public class EmbedManager {
     try {
       PDFMergerUtility merger = new PDFMergerUtility();
 
-      for (String s3Url : this.s3Urls) {
-        byte[] s3Data = downloadFileFromUrl(s3Url);
+      for (int i = 0; i < this.s3Urls.length; i++) {
+        String s3Url = this.s3Urls[i];
+
+        byte[] s3Data;
+        try {
+          s3Data = downloadFileFromUrl(s3Url);
+        } catch (IOException e) {
+          throw new IOException(
+              "Failed to download embedded PDF document at position " + (i + 1)
+                  + " from URL: " + s3Url + ". " + e.getMessage(),
+              e);
+        }
 
         try (PDDocument embedDocument = Loader.loadPDF(s3Data)) {
           merger.appendDocument(originalDocument, embedDocument);
+        } catch (IOException e) {
+          throw new IOException(
+              "Embedded PDF document at position " + (i + 1)
+                  + " downloaded from " + s3Url + " is corrupt or not a valid PDF.",
+              e);
         }
       }
 
@@ -90,7 +120,7 @@ public class EmbedManager {
       }
     }
   }
-  
+
   private byte[] downloadFileFromUrl(String s3Url) throws IOException {
         URL url = URI.create(s3Url).toURL();
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/src/main/java/com/materialidentity/schemaservice/FoManager.java
+++ b/src/main/java/com/materialidentity/schemaservice/FoManager.java
@@ -61,9 +61,27 @@ public class FoManager {
             Source src = new StreamSource(new StringReader(xslFoInput));
             Result res = new SAXResult(fop.getDefaultHandler());
 
-            transformer.transform(src, res);
+            try {
+                transformer.transform(src, res);
+            } catch (RuntimeException e) {
+                throw new IOException(getPdfGenerationErrorMessage(e), e);
+            }
 
             return outStream.toByteArray();
         }
+    }
+
+    static String getPdfGenerationErrorMessage(RuntimeException e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t.getStackTrace().length > 0) {
+                String className = t.getStackTrace()[0].getClassName();
+                if (className.contains("PNGImage") || className.contains("PNGImageDecoder")) {
+                    return "An embedded image contains a malformed or truncated PNG. "
+                            + "Please check that all base64-encoded images in the certificate are valid PNG files.";
+                }
+            }
+        }
+        return "PDF generation failed due to invalid certificate data. "
+                + "Please verify all embedded resources are valid.";
     }
 }

--- a/src/main/java/com/materialidentity/schemaservice/GlobalExceptionHandler.java
+++ b/src/main/java/com/materialidentity/schemaservice/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         Sentry.captureException(e);
         ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
         log.error("I/O error occurred", e);
-        apiError.setMessage("An I/O error occurred. Please try again.");
+        apiError.setMessage(e.getMessage() != null ? e.getMessage() : "An I/O error occurred. Please try again.");
         return new ResponseEntity<>(apiError, apiError.getStatus());
     }
 
@@ -79,6 +79,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST);
         log.error("IllegalArgumentException occurred", e);
         apiError.setMessage(e.getMessage());
+        return new ResponseEntity<>(apiError, apiError.getStatus());
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<Object> handleRuntimeException(RuntimeException e) {
+        Sentry.captureException(e);
+        ApiError apiError = new ApiError(HttpStatus.UNPROCESSABLE_ENTITY);
+        log.error("Unhandled runtime exception", e);
+        apiError.setMessage(
+                "The request could not be processed. Please verify the certificate data is valid and try again.");
         return new ResponseEntity<>(apiError, apiError.getStatus());
     }
 

--- a/src/test/java/com/materialidentity/schemaservice/RenderTest.java
+++ b/src/test/java/com/materialidentity/schemaservice/RenderTest.java
@@ -225,6 +225,31 @@ class RenderTest {
 				.jsonPath("$.message").isEqualTo("Certificate type 'invalid' is not supported.");
 	}
 
+	@Test
+	void CoA_renderEndpointTest_MalformedEmbeddedPdf() throws Exception {
+		Path fixturesDirectory = Paths.get("test", "fixtures");
+		String fixturesPath = fixturesDirectory.toFile().getAbsolutePath();
+		String fileName = "malformed_embedded_pdf.json";
+
+		String jsonContent = new String(
+				Files.readAllBytes(Paths.get(fixturesPath + "/CoA/v1.1.0/" + fileName)));
+
+		webClient
+				.post().uri(uriBuilder -> uriBuilder
+						.path("/api/render")
+						.queryParam("attachJson", true)
+						.build())
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(jsonContent).exchange()
+				.expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+				.expectBody()
+				.jsonPath("$.message").value(message -> {
+					String msg = (String) message;
+					assertTrue(msg.contains("position 1"), "Should mention position: " + msg);
+					assertTrue(msg.contains("corrupt or not a valid PDF"), "Should mention corrupt PDF: " + msg);
+				});
+	}
+
 	private void assertPdfContentEquals(byte[] expectedPdfContent, byte[] actualPdfContent,
 			String fileName) throws Exception {
 		try (PDDocument expectedDoc = Loader.loadPDF(expectedPdfContent);

--- a/test/fixtures/CoA/v1.1.0/malformed_embedded_pdf.json
+++ b/test/fixtures/CoA/v1.1.0/malformed_embedded_pdf.json
@@ -1,0 +1,125 @@
+{
+  "Certificate": {
+    "Analysis": {
+      "Inspections": [
+        {
+          "Maximum": "35.00",
+          "Method": "DIN EN ISO 1133",
+          "Minimum": "18.00",
+          "Property": "MFR",
+          "PropertyId": "1037",
+          "TestConditions": "2,16 kg 190\u00b0 Celsius",
+          "Unit": "g/10m_",
+          "Value": "30.56",
+          "ValueType": "number"
+        },
+        {
+          "Maximum": "110.00",
+          "Method": "DIN EN ISO 1183-1A",
+          "Minimum": "85.00",
+          "Property": "Density",
+          "PropertyId": "1039",
+          "Unit": "g/cm\u00b3",
+          "Value": "104.66",
+          "ValueType": "number"
+        }
+      ],
+      "LotId": "123456789 11",
+      "PropertiesStandard": "CAMPUS"
+    },
+    "BusinessTransaction": {
+      "Delivery": {
+        "Date": "2021-12-13",
+        "Id": "3000/21",
+        "InternalOrderId": "3384048234",
+        "InternalOrderPosition": "000020",
+        "Position": "1",
+        "Quantity": 90,
+        "QuantityUnit": "kg",
+        "Transport": [
+          "W345678"
+        ]
+      },
+      "Order": {
+        "CustomerProductId": "10011",
+        "CustomerProductName": "Plastic",
+        "Date": "2021-12-01",
+        "GoodsReceiptId": "1000_10_10",
+        "Id": "1000/12/12/2021",
+        "Position": "000010",
+        "Quantity": 100,
+        "QuantityUnit": "kg"
+      },
+      "OrderConfirmation": {
+        "Date": "2021-12-01",
+        "Id": "22"
+      }
+    },
+    "CertificateLanguages": [
+      "EN"
+    ],
+    "Date": "2023-12-12",
+    "DeclarationOfConformity": {
+      "Declaration": "This document is valid without signature."
+    },
+    "Id": "1451445432",
+    "Logo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUAAAAB+CAMAAABiSTjxAAAC+lBMVEX///+a4XxrumL+//79/v0wdHGc4X6d4oCa4Xrp+OSR322P3mqV4HST33CY4XXI7bme4oH7/vptumP8/fyY4XiQ3mtqumGU4HKN3meZ4HmW4Ha96quZ4HtquWGP3mjt+en5/fmp5ZFuu2ad435xvGj3/PWz55+Q32yh44VzvWtvvGeY4Hbm9+C36KSs5pTf9diu55fA67Gg4oOd4X+T326J3l/u+uui44cwdXDr+efk9t2e4oP0+/Ho+OLK7r1nt2DZ8tDC7LMsc2+L3WLz+/Cy6JxpuGJtvWH4/ff2/PSo5Y6c5Hy66and9NW/667x++7t+ejj9txBeXcobHBouV8AXlrX8s7G7bi56aew55mf5IFktl4AY15WtEmb4nv2+/Lw+uym5Iw0dXKR327V8cvP8MO86qqk5Ik2dXOM3mRrumRStERPs0Hh9drT8cm16KGb4n09d3UydnBvvmRetlNatU/b89PL7r/F7Lah44E0d3AAZWJmuF5juFn0+PTJ4sfM78A5dnMtbnIucXEja3BUs0fl9uDS8cc7d3Uyc3GG3lkAW1Vht1bs9O3a89LO78GfzpqZzJVHe3qQ2XZ6wHJuvmH0+/Dw9vDw++3e7t3R8cWkuraV3HlLhngocm92v20Aamdtu2X8/v35+/qv16mFynaK03I5fXEhb2xzwGXo8+fc5OHW39+TyI1fn3Zwum2vwr663Leeta+Nq6Sk0aCU1oCCw3s0cnR+xXJIi29Ytkrj8OLY69XQ5s3C37/E7bS22rOr06ZqkoyIxoFpsHCDzW88g2xQmWlhrmXn7Ovg5+Xa7NjN2Na4yMZ1nJOc34OKzXllo3kXbmt9yWpapmhntWQAbGJMsj3U6NO+zMu93LqqwbeAoJ6Z3IKLz3lWlHY2eXCR4GsOampjsmSD3VHk6unl99/I1NG8zsWo06Rfi4aP0n08cnhEgXVttHGB3E1+3EfD1MqXsqqEpJxTh4BwrHtprXMbeWZUq14ATlL9//ui3JGZ1YsujFtRR1yPAAAZqElEQVR42u2dB1gTZxiA/yPH3XG5KxdIyEASZgwEEggBZAqykSmUVVCQVVREW1So0qqttbW21tYuO+3ee++999577737PP3+S8gywaTt87QlfM8TuMv9t958//f9//cvFLhIyMhIUuLlaxK+nZV90YskbRvnndKTW5g3UldnzkvNzS6IdVBEs+Kbno3OKacddvfxO38zqOVGDkRjVAu96WklW/N6SDHVrB7uJU4uhz52zc5dk2u2nHSiXGOUq9UMo1bL5RpOaWWtyglTRquOnGXok94phx1/9prusQ0bKp42JBCUhxCMnOubK0/fGDbL0FvWTbr9+j3L12zYEx8/P+WGTmYO4UUAI8Nplem7e/BZs+bQBd+xd964fEtLYsqykJADzn6jU034FIqmlComukk2i9AmkfC57fzEl8YSkyNCooDfzU8tBH6+hSFogVBYy+vAM88WbEgS8H3SsmJDciKmFwH88hfPIaYXhqGETPadjrWghUGuhJGQec+PWt6SnBIF+IDf/AsEB7/p1VCgWKu+CaFg1kGwYZLDzt6yAfABPTs/cB9+CWghwXL1DUFMkETo0p23TiamhNglEH4iQprYVh+8Ogj8DgtZs8eBD/xHQPyw5LODEiQJSoYSqHUcv6UlJcKF382B8iNoNhoAkkFIEN75tF3diS74Ijbswv43QIBzASAK2x103hhn37HtyVGu/BLfWOjCj2GIqcqcuMdMA7AwK0MWXAQjEXn3ipjEGBd+UctucPBjCIoW8gWaosRtvJNPU0DRlwYSKn1BMOXiSBR7/YqUeODnYgA/65wzRU8QKI1Cq9UqrErjfkoWb0o5grbQBONdA+X5irjs4CEYic47fkVifJQLvghwwGp76Y6WK1RWg76+qHWkKS81NW/E3F+UkVbDSVU8VEC8aqCRMGS1BY0nIVHszuXJe1z5xW84+ynRgVC0XKuYaB84skHmcVJB7nHjJqWKy8z0AnA/cMdBA5BEkcevSI5w07+WPaIBpCil1HDXyJIpEBKbOLjE5u6IY/sIyhtAaXiQAIRi2yfAL8RNDnizE0wfw/MdxdUIi5Obx65sZFA+10hRQQsQ3vHulxKXueGLgBL0YsDHpTVJRFpeQTiOZLdNsBqKClqAh63AlTe3DBx/QyfF86MfIj8CfPh4WZGFVdNBCZBEj61Z5pF/IYSQo1bE1eHD/oYQe0qMvEAxQQcwEh2bPOlWfsFVkLNzlFx4kl37/EWYZ5JmZjJBBhAc8BVrEoGfm1TcYO1tCjA6D4mTSrQMnRlUAMEFXLMlJcST3y6+dgkgCbwlqp/jDIpgAhiJTptsiffgFz//wgFJ4I1DIvFUA8cHEUASnQcZ2B1fVPzkJWs91c/PECmkaEjfVh80AOHtnvj5kmXu/FI2bL/d7cW9Fp99m4SquFHkFSAcnGl9F0j0wVHPXxLjzq9l+8uYw7TGjpRMc82CrTIvACUzsL0Y3ujbX344OMaNX8jYHW7qhyIfueyb106/FuT01z6+7NFjJfYub76vCqw8AUrE5LKGwuKtO8LDB1rrqtAMEAm6/MXNzxwctczF/sXfepib/pGo6slf1h9jl/3Xv/j9d6c//kgkHPGFEDMjPQBi7YtN3ag38BBIVKkUiqzCGWAdwdG+3vX5LSkhThWMSOy+xsNuoV/Pf/DzE+yyaNNN7+6///5ffPfxoxLfCCUeALH69ezu4FRzNRQtCJZ8CzUxE2KtoIBdi44486ooJ8DE7uvh7T3U6a7nLmqet0CU0KVLjzph0WqAeNF1jycBQu8U3AGC+lWvy5GyhCDQlNiWIvCmpBkAEKHX1y8666b7Kx0A48duPBRFemIuemfXvM0HhU4JUFx9wupnu1689+NDgc4+AUKKuhoFRwvUVPSfyZfWSv7/AEl0+fpNofOan3F4kYiWydOAn2eyfqX6hbdFgk6I81YvOnz9+k+/AQ6S6QFCuSaD5zLd2k4E7cAMKCFK0HVdRy045Ii3UhwKCAaQ3JtFqmbxiQ8/2AwE3eTAo44+p+vJyyDFdABJlB2nINybTSiC+/D/z49Ej5y14OjQQ7ARtPPbfmOVN4BlORz93Hu3NIfO80C49MAD17/4WixomU+AUJ4ReJpwE0awmpL+/23Gkejqrk2hoUfP23x/pb0I2P0yIr0V6/Q8fcYl8x86fPM8QOgum2465t4PAJhPDcxN4Dz4EXBg3f8/B0Mt+N5zlgKCg464UjSCUYlrdvpIWcQSCSeGVD5/UfPhB3kinLdo/U8fQSJvABXjqMGgpBkPfpnGhNyZoICXn7MAAOI8bAsHxq85DXl3CE0cQyRcOP+kFx6a1xx6iAfBBYuau66G+sreAIXhdbIOBc146X30/1dAeMXTuw48WiRw05eVoIDJW673lTKpV0PMWXjh/MqTHr5lc/O8Q9y18KzVRx3zrQwIegKkFEVtLEV4CqWWp/7/FZBEh957DphARx6O8KWAWFlKMIeFD8yPOSnk+Qebm48+xNUjH71g06JjrjsXkZ4AGWJoFUPsDZAtmQEjSiLRZQsuPtAGsBn74eTunef6AAh5mCeIOQToYEVlZcXzt4Q2bw4FY+gkeMii/a8jEekBkCDkhBd+XE7B/18B4Q2e6Fq61O4HNv9YuSxxOQ7C+NBAWRxHiQQrKkJCKkMefujB0Obmw0PngYgXWHDI6mOuhYSeACnCi1jNM4KfBErRU470iLcOTsGVONJn6gEt9gXgiyPmhwDCypiHH7rl7QXNzZs3H26To2865mrImG4AvQqlGvj/OxCcg0/59JzVDkd61JeJK+727RklqMxuzBKgPBgTgRmeFPLCw88/dMuDF1309iGHvH3RRV88+MfLKHIfABmCVpXMAA9sN4HgQ+zSfOXBY49Nm7HGtQIgBF8854Go+TD2ISYGQ6ysDKl44b33Hn7vhYqYxO1nH4sipwXIULQqegZEEcQXfKXrwKWOwnDzmQfceMo0ACUoW24zaHMWLzzxkvkVEVgLYzBF4IgF/oMbkiHSN0CGEShVNPkf5+dfywOkOX3/1Uc7AC74/KHz95Gz2lQWRiQ4J2HOAwfbEWKJsQnEcpJX3Alm0BdAhrIoreHkv+BAJAHMS0Dij1/1uNe7FoU65JDNPx027XlgBQ0a8CM2JUw444GIAwBhhEdzXkXUpcgHQMDHqHrr4IiPdwT5p3jZ5S+2EiWBjfGrGL1+0QJnSODisy5HkdNfuVVLAwibEi5ceAZo4fyYEDeGMcndx8Pd9waIu1gTKnVRgQ9+pMTx/58U+08ikYH4q3/VJXG1PUjiRyjrhHePcmrgUed8f+y+AJJpCoGZQkgsTDjjwueAYUWIK8Tk5bd7AUjRlEYlL9H5GNKOv5OV6bKT8PY/kmFJ/HH0B6iqTY9b568CFmVxpbX+ALz82QWbXACuf/I8RO7jlOxODjKxA+GqhYuB4SUx84Ei2EAcj6hIWXNfpFsWxnMCaHgp31uU7QsPfJmXEZeT0Nnb3ir72wQlqKfD1JEOUp5WlCr+ZNVDbFa0H9leTJxRmq/Qw8Y+AT6+fumBzrrYpq5r93kSieqsDHhiJ0JguHDOiRc+8NwlBx8M47Jxhk6+9XZEOgBSGpZjLEOjA0fGig/pw7qmsbyGA1EqTKmwj98Gf1wtmod9c+zs3fEYNe7Xp+GxKHm+vQCHQkxqPsPDOLrtkqihPL1mJQLFRToTN1SISOdx97ROGB/tf9RSl+h819WI3Ld9LdLuVTdbnLAwYRUx54wzTgQ54wyiL82pgZl82khqbgPA85054ZE7FbTcaqRX8bzQpwxzfw7Hy3rbdW65EEY6Wk0zRqOR4+W0Ki4JvEKcnM1wS+NxDRL1UHxWkT3Ln0qKh5zoXNM6v3xl/9Uuofmj17+CSD88/KCU9iQILgUwrkpYiGXVYoIDBHaAgnad8yF8hsri+vI5w8ZUXWNdGs+OA+3YsrKTEapqXCI+r6ynMbva+R5J2brsWLvdPLmsjESx2Y0NMle0ugSKb88tLGzakcMZSsMdAMWOEbrGhiqcCH/wqbqyKhGggWA3igZTVpBUEGs7TDbodHAD8WtUnd2YfbLMBf7VbgDPOudxFOnPYJJypyPxxIgFx6raHABpRRsugkmmt9pSgYvLtu0NgBbI0NqEibjcVpN1K1xF1q/PIYS48WwgCIlPXmfqJCbSB5JwW33ukGHCbE7vlE901DkIYoC0qk3cThXkxFASqrZrYMNufe8qKse0cYnIZMnGdAOT0NtRklt9VxrorKmkfSuJPuycYOqw/ybXpuXQCTlpZrEaMW7qVAs15UXgoO0AX9t/kUsOvvjiywCgHwSXmNh8hphONEPViHRrF57+gjUcweSic0kQe9GjVcXRHbxGtRKhJXotL9Wq+rT0CEZWOKTiVVr4mHrgcQuNvDrOKOXnEKx2I3LRwExtCVxHBhmGpYhctMQGsMo0zKukUqVmuKYRt5TFlbJSqbRU8f7u6uEsiqCUpV/rSTQCNy6Gi1fXqniNVKHhtTsQKkxQ9UkVqmFVFrB1VETcAT7qD0B83xqFZXqCfF0gAJuMBF+PyKnfFVv0YqVAaTj5OyuRTD8sqEfXleQQSgCBTrX0UQn16wYXU1oTZLMwgbFoeCFuFWch3gHD79RAACgB3UcZCooJmwKIirbllA/W5hhzSkdJBO7WIqQVtUXnCLFLagw0w1hq6BIS5TGUci38WLVZFnWCfnQVIXy9FpkUBkP0uvFaeTmorleAz170CAD0j2C6NJ+YBiHVV48k/gNs5TOlrYh0ulUAyBIUN9qUW4CKhy3cbriArpfCzSj1LCU0QTLzYkqxEgBSmkwuurFAl8YLfLgbwHFxu6CXoyYK7FlYggpKUmUkOjVdQzGFKLaGsZbg9I15YPdGLIz1rgJdAQDUMOxxCB2ntXDpuTIyrIYvKWuQC2w/ftrUXLiMV4DvPpPrH0Bs9dNUFDUNQK53CWiUvwBXzqXn2vIFnNKh1zciAJip7KhCIHoNb3PqdfwcYUmSoLbasmobz+llqJCSy+OwwdcJci7NNQsrMmRVSSfn6ZUWRS2yAXQ+iJkV2DoIEcs16XllYpEL11PVigHYFAH2FSNZO0szomHWpSLUoM7kBgsLbA/sDeC8wy86+1I/AeLsGc4aM30DVGuaAgBYDBrYby86NmlZPhUAWikevgKXlSOX19SOpqW16ylC2ajj1Ew67I7WphOamjIAqObDxXTpHKd3AaimhJqamhwjR3PGRhcvrNtRD9cqZ2gt6FhbFqWxdpoG+wtwHQEAroOntgOEXM/hn8TuACX6UkGpzEnPOC7WxQu7Atx85Ul+AxT7CgmQy3wSZHcgid9ZOE9OKNMglbhtJFYVImDKcOJvUGAwUlyWKOzcbamFvJq2boOdbaXsMOhHKsXMXYnTycqVbgDltByXozmOnchDpANgP8uq4GwVlaktRig2WtnHs6xVOwG/WY8IUIJsWbgY9fSq2RJbmR7foKHDyuO0KtOpDifyBESznNHA+Mnb/AaIL9qQxnIU7d0UZrLtAdjAKpOSAlzY6KNUTk2kigA1R+IHlfWquQ6z+bi1a80ja1tlOrmaq8+DvbVmc7G5CjSQUfR7A6imiISEVRND5bjA4gCYyhJEeX+deYeclhbjy4dtrS83GGm2JgnpAOBGFw2sNinlHfAWpKOyuWMwnZYLpYPI7kWgJrIaaiL2Zs1nKqFbeWRAoxlahxQc7RUhzcdVI5l/AOFKu7WCxnCkuNPEqUEDHQAlKJpnck5FWGTwSaoxTnEiRZPpSwMpa21PI5R77YVgO8AdLJNTDSkaeQEAIluARlakZKhC1DMkZ4tcbCCZobAozQhk7Y4qSCWCTKrlNHFg3+11YUdA+qCzvrgqagyHAwMieHKRQYr7/DGeDDM1tM5vgPD2epVBzWXU5TWtTCcoCjSw1armbABTtfkaQ2ujLrWksxAuOaCy8OlmXe5IuWkJvgOhVtgB8koXgIszh8ed4TEMUIMBFrGUBbxo0iAvqADgSHpr7hIZuZGjqFzQOI6oCTs17FzUpFFjL5yqJKiElbmNWxkFjNjaWm7WVctiozVGU5UdIPTrCD3QHkyFdvWIW6FfW6CDkrKLhrQ8Jc484WYDGY0ZnesnQLjryemlRD7PyzmrXFBxYVCEkOdT9q4LG7MIghvqTZAr6FMhrpdWmqmW9w7J5aXlwCY3P5+zZeFRhnB64WxDDjeOSBB7ZktKp40lQGw4n4pbN9ChsuQoj0MyU6kxx6SPU9Ol7bgTbqmBysmpaUBNdL4RlwoGhtWZys4JZT4xXFjNSJmhdP0QQ2VtBFtjH96w6NnVdgVc/WVlfPc9gXYWwI/XsDLdquIJQbDPggIg8Ydt9R8gNoNtcgXPaTRKlk03g9npf780Kw+ugE9dmQCWXyVluZIknHJcySpUWsVceiuul6hKvxoQAdZs2xbnME65KsXX0W4xUkvW++1wpG2YVW37alv74tKvVqIyE68oLc3K0mr1BXCvk01ZbF/ptq3InDX8fiuot6R/lYJVSK1aQx4qFDgtpC3VsiVwwDMijTtYRqWsuaLqr4yMQ7F54SZOK+UY3HmcFkWwKHb75USc5kA30J5eEzca3hSLd4+srY/W2YuG6NSV0fqOtPBUe50+bGOtvrx2IFuMAGTUt4+IfnLd4OAOZ3QsI6O91dVIxIZH1/bjLXM9nFtX3RZdCzY3yVxUW16eNm6W2Qzl7vbytHAdyo2uh6MkvvPWQb1+cGUBnFhwXFt7ub49HE6T7NUmsuCmHytjUrbvEiPSgSMEhrn9GXGMcu6wSqpgQUGG2W1tgQC0oYqtTvIyC6u4J4sVjzh3bZuBikQ81+2bWLcr4x2J+51ljkciYx23dbbKiQoo9tKPb5nEgdCAxTFrQlnq2q3r2kqi68eLdhePlAUC0EnNE59bVM5zN1BxXsPrlX3f2eP5PNuFD2oWu2albHk18KfyPf4tMICecWe85XN0nrd07imcO97TwR+Pezp23c/eK3rt3r3yrIs3YRdylDjKIbF7Z6SbCgaOkbTfnxRDAjN9tKa9b4w9BwPAyeRL/8Em75kPUGLrnXU0VIMPblkWAnm4G4bIzQIMqH/g+qVLDzpr0/0nVYSIHXyPh/6VswADyMOPzrt4E+6cahurmbIh5NJZgIGNcnhy/SboWpkIORhL8kuvwtvOAgzgFa/uOjD0pmdwDhZHiWy/8dBZgIF1sXx2weEHYhNok+QVd8wCDGy09ZMvHn7mVZCD7So4dt95SDILMAAVfKJr8y1nA8ApgqCC5CzAAN7x2EVHXAnVkCmJn7wRWvxnAQaQia/d/4eDwQQ6VHALhFVnAQYA8NFzsA9xSkwLtC3NAgxArvvZbdad+LErSETOAvRfBS87IGJPiCvBbhzVmgXof0Th+C3JUa4AWyYfQ5GzAP0neNrYHre57xLHcGx/FqDfANE9y91UEIYbXRH7twkGQUDVoSiXJk4muhNc7jl3UeDR6aDRQPyudy6HBUTcCZ6P/o4O4vZiWbBMwIgbqz1msIyKSPxbBOE3qasngwYgnkM1qiXek+AnkX+VIPAya9tR8ACUkOjO7vhl7gRTlu889K/ZQTipX64KnjlUbYP/d3Z7TgSfuOU+negMAr9YOEsF0yy+4kufsmu750zmKWs+M6NAEULqglEFkR9U80iLBE/b3uJJcFn8iXclBYQQpzQbWCro5tIXV3NYngIEPVYjUPaaMV6J/73d6qH3eRCu5oDlGo/1bGBFr4obGGm0DrMh/ZpnIGkrrcikmKAEiKt0exHckPiUoCXCs0WEvjHYj8YWx6nkQpAuyILNoOz45R5rAsXDqsKCWjUxnkr6mrfB8X1Ba8dcXqCZoAWIayR4VSqPVYHeTKAEjYJJay2zwXKjKJkaV1+V11bD9lHC3otSKYqCBqB9Xb4IN4AhFbCuF03LWT6nvjhb5rVH4MnmcZORVQI+Zi+AlhkyS5HfQ7jOX7Es3o1gi7i0JkUTHMsnpGe0pp4qc11VLsy8bjRHySrVFE15WZiP1nDm4OGHCaJXb92Q4kZwvm1tPrwYqVxpnasUejvao0vawksGRztMBjnL8hoGDnpd2ZDhE/KCiZ+Y2e4IGYMCodviaBb78sIUBqXmlHwfq1CweCiakaHs8LwChHHNwcVPrHbcdl/3HrcA6wEXGOwECQdHmqac6HwBTE2rngHTBP6FiUHvWTPpViI84OlOIBiIZCpwNKYqyFYXdjhjdFjylmSnEsIi/093qgPhx+QrByWIDLr1rZ0EL925YjI5PspZmHkzAIIMIWRuy0Boxi3+E8iMXZGH7XopJnlZ1F8gyGTSCq4tqFa29jqA65S7o5bHpEQ4c7GF8Ysflckr0sKCqPTsO7J37Pkh3Rvi90SIBMEXW/a92D/4ZX5ux4gk6PlNIbx7V/dYTHz8HtEX3/xUwpx90DNaleVmEs2ASbb/CcEUDj3siu23bo9KSYwHHTz7jQSvxRnI27hgaOStlvojZ7XPwxbKHrtn11j32IaUxORl8Z91Mmo3dIwIT8BVZXaxfmUDCtaiiy8hIxH4kzvuua9ly5Y1LRHxT+cY7HUQ+AC5/HyBZpSslLfoB8Jw3p3F5ykScdWuQ0+78/r7Qm5d/tLkhXK5PbbAqDW8QiqV7jc0WrRWDHWRs/i8I4wU/x1628t3nn/8Fb/nMxolO9fKyVcZ4vTRRcWpZbKZuu4j+uenYZZUnaJrDCs88sjCsFxdT7VsKqvPKt8+hfTVJiIhZ3XPX5F4yMxb7NZf+RO6hV6fyb2PtQAAAABJRU5ErkJggg==",
+    "Parties": {
+      "Customer": {
+        "City": "D\u00fcsseldorf",
+        "Country": "DE",
+        "Identifier": {
+          "VAT": "ESX12345678"
+        },
+        "Name": "AncientCars GmbH",
+        "Street": "Fabrikstrasse 1",
+        "ZipCode": "40310"
+      },
+      "Manufacturer": {
+        "City": "Ingolstadt",
+        "Country": "DE",
+        "Identifier": {
+          "CageCode": "",
+          "DUNS": "",
+          "VAT": "DE999456789"
+        },
+        "Name": "Green Plastics AG",
+        "Street": "Lego Stra\u00dfe 57",
+        "ZipCode": "12345"
+      },
+      "Receiver": {
+        "City": "D\u00fcsseldorf",
+        "Country": "DE",
+        "Identifier": {
+          "VAT": "ESX12345678"
+        },
+        "Name": "AncientCars GmbH",
+        "Street": "Fabrikstrasse 1",
+        "ZipCode": "40310"
+      }
+    },
+    "Product": {
+      "FillingBatchId": "210000",
+      "Id": "20000 20",
+      "Name": "Super duper plastic"
+    },
+    "Standard": {
+      "Norm": "EN 10204:2004",
+      "Type": "3.1"
+    },
+    "Attachments": [
+      {
+        "Hash": {
+          "Algorithm": "SHA256",
+          "Encoding": "base64",
+          "Value": "fa9e2171dbcf4c73e96fefed7be1582cebc3d42859df423afcea0b4439c4cc48"
+        },
+        "FileName": "Curves Ultramid B3WG6.pdf",
+        "MIME-Type": "application/pdf",
+        "Encoding": "UTF-8",
+        "Data": "data:application/pdf;base64,VGhpcyBpcyBub3QgYSBQREYgZmlsZSBhdCBhbGw="
+      }
+    ]
+  },
+  "RefSchemaUrl": "https://schemas.s1seven.com/coa-schemas/v1.1.0/schema.json"
+}

--- a/test/fixtures/EN10168/v0.5.0/malformed_logo.json
+++ b/test/fixtures/EN10168/v0.5.0/malformed_logo.json
@@ -1,0 +1,389 @@
+{
+  "RefSchemaUrl": "https://schemas.materialidentity.org/en10168-schemas/v0.5.0/schema.json",
+  "Certificate": {
+    "CertificateLanguages": [
+      "DE",
+      "EN"
+    ],
+    "CommercialTransaction": {
+      "A01": {
+        "Name": "Steel Mill SE",
+        "Street": [
+          "Stahlstrasse 1"
+        ],
+        "ZipCode": "4040",
+        "City": "Linz",
+        "Country": "AT",
+        "Emails": [
+          "certificates@steelmill.se"
+        ],
+        "Identifiers": {
+          "VAT": "AT123456789"
+        }
+      },
+      "A02": "Mill Certificate EN 10204 3.1",
+      "A03": "1866645/001",
+      "A04": "data:image/png;base64,iVBORw0KGgo=",
+      "A05": "Factory Production Control",
+      "A06.1": {
+        "Name": "Steel Trading AG",
+        "Street": [
+          "Handelsgasse 1"
+        ],
+        "ZipCode": "10115",
+        "City": "Berlin",
+        "Country": "DE",
+        "Emails": [
+          "certificates@steeltrading.de"
+        ],
+        "Identifiers": {
+          "VAT": "DE12234567890"
+        }
+      },
+      "A06.3": {
+        "Name": "Steel Warehouse AG",
+        "Street": [
+          "Handelsgasse 1"
+        ],
+        "ZipCode": "10115",
+        "City": "Berlin",
+        "Country": "DE",
+        "Emails": [
+          "certificates@steelwarehouse.ag"
+        ],
+        "Identifiers": {
+          "VAT": "DE12234567890"
+        }
+      },
+      "A07": "0334/2019/ZZS",
+      "A08": "958722",
+      "A09": "TR-12456",
+      "A96": "1",
+      "A98": "DN-1583836",
+      "A99": "AV-87682933",
+      "SupplementaryInformation": {
+        "A10": {
+          "Key": "Buyer Reference Number",
+          "Value": "BRN-1583836",
+          "Type": "string"
+        },
+        "A11": {
+          "Key": "Reference Date",
+          "Value": "2018-10-23",
+          "Type": "date"
+        },
+        "A95": {
+          "Key": "Custom Field A95",
+          "Value": "This field should be valid in SupplementaryInformation",
+          "Type": "string"
+        }
+      }
+    },
+    "ProductDescription": {
+      "B01": "Seamleass Steel Tubes Hot Roild",
+      "B02": {
+        "SteelDesignation": [
+          "S355J2H",
+          "P355NH/TC1",
+          "E355+N"
+        ],
+        "ProductNorm": [
+          "EN 10219-1:2006"
+        ],
+        "MassNorm": [
+          "EN 10220"
+        ],
+        "MaterialNorm": [
+          "EN 10297-1:2003-06"
+        ]
+      },
+      "B03": "Ausf\u00fchrung lt. EN 10219 Teil 1+2 /--/",
+      "B04": "normalized",
+      "B06": "SST 200x150x6",
+      "B07": [
+        "7282841",
+        "7282841"
+      ],
+      "B08": 16,
+      "B09": {
+        "Form": "RectangularTube",
+        "Width": 200,
+        "Height": 150,
+        "WallThickness": 6.5,
+        "Unit": "mm"
+      },
+      "B10": {
+        "Property": "Length",
+        "Value": 12000,
+        "Unit": "mm"
+      },
+      "B11": {
+        "Property": "Corner radius",
+        "Value": 1.5,
+        "Unit": "mm"
+      },
+      "B12": {
+        "Property": "Theoretical mass",
+        "Value": 5738.3,
+        "Unit": "kg"
+      },
+      "B13": {
+        "Property": "Actual mass",
+        "Value": 5739.3,
+        "Unit": "kg"
+      },
+      "SupplementaryInformation": {
+        "B99": {
+          "Key": "B99",
+          "Value": "1607219/0001_20181023_1529",
+          "Type": "string"
+        }
+      }
+    },
+    "Inspection": {
+      "C00": "175508",
+      "C02": "0001 l\u00e4ngs",
+      "C03": "-20 Celsius",
+      "SupplementaryInformation": {
+        "C04": {
+          "Key": "Sample Identifier",
+          "Value": "10001011/175508",
+          "Type": "string"
+        }
+      },
+      "ChemicalComposition": {
+        "C70": "EAF+LF+RH+CC",
+        "C71": {
+          "Actual": {
+            "Value": "150.5"
+          },
+          "Symbol": "C",
+          "Unit": "%"
+        },
+        "C72": {
+          "Actual": {
+            "Value": "0.005"
+          },
+          "Symbol": "Si",
+          "Unit": "%"
+        },
+        "C73": {
+          "Actual": {
+            "Value": "1"
+          },
+          "Symbol": "Mn",
+          "Unit": "%"
+        },
+        "C74": {
+          "Actual": {
+            "Value": "0.014"
+          },
+          "Symbol": "P",
+          "Unit": "%"
+        },
+        "C75": {
+          "Actual": {
+            "Value": "0.007"
+          },
+          "Symbol": "S",
+          "Unit": "%"
+        },
+        "C76": {
+          "Actual": {
+            "Value": "0.041"
+          },
+          "Symbol": "Al",
+          "Unit": "%"
+        },
+        "C77": {
+          "Actual": {
+            "Value": "0.02"
+          },
+          "Symbol": "Cr",
+          "Unit": "%"
+        },
+        "C78": {
+          "Actual": {
+            "Value": "0.009"
+          },
+          "Symbol": "Ni",
+          "Unit": "%"
+        },
+        "C79": {
+          "Actual": {
+            "Value": "0.002"
+          },
+          "Symbol": "Mo",
+          "Unit": "%"
+        },
+        "C80": {
+          "Actual": {
+            "Value": "0.01"
+          },
+          "Symbol": "Cu",
+          "Unit": "%"
+        },
+        "C81": {
+          "Actual": {
+            "Value": "0.002"
+          },
+          "Symbol": "V",
+          "Unit": "%"
+        },
+        "C82": {
+          "Actual": {
+            "Value": "0.001"
+          },
+          "Symbol": "Ti",
+          "Unit": "%"
+        },
+        "C85": {
+          "Actual": {
+            "Value": "0.047"
+          },
+          "Symbol": "N",
+          "Unit": "%"
+        },
+        "C86": {
+          "Actual": {
+            "Value": "0.001"
+          },
+          "Symbol": "B",
+          "Unit": "%"
+        },
+        "C92": {
+          "Actual": {
+            "Value": "0.327"
+          },
+          "Symbol": "CEV",
+          "Unit": "%"
+        }
+      },
+      "TensileTest": {
+        "C11": {
+          "Property": "Streckgrenze ReH/RP0,2",
+          "Value": 377.12,
+          "Unit": "MPa"
+        },
+        "C12": {
+          "Property": "Zugfestigkeit Rm",
+          "Value": 456.18,
+          "Unit": "MPa"
+        },
+        "C13": {
+          "Property": "Bruchdehnung A5/A80",
+          "Value": 29.7,
+          "Unit": "%"
+        },
+        "SupplementaryInformation": {
+          "C14": {
+            "Key": "Re/Rm",
+            "Value": "0.83",
+            "Type": "number"
+          },
+          "C15": {
+            "Key": "Sample Identifier",
+            "Value": "10001011/175508",
+            "Type": "string"
+          }
+        }
+      },
+      "NotchedBarImpactTest": {
+        "C40": "0001 l\u00e4ngs",
+        "C41": {
+          "Property": "Width",
+          "Value": 5,
+          "Unit": "mm"
+        },
+        "C42": [
+          {
+            "Value": 71.2,
+            "Unit": "J"
+          },
+          {
+            "Value": 84.2,
+            "Unit": "J"
+          },
+          {
+            "Value": 85.2,
+            "Unit": "J"
+          }
+        ],
+        "C43": {
+          "Value": 80.3,
+          "Unit": "J",
+          "Minimum": 78.5,
+          "Maximum": 90.6
+        },
+        "SupplementaryInformation": {
+          "C44": {
+            "Key": "Sample Identifier",
+            "Value": "10001011/175508",
+            "Type": "string"
+          }
+        }
+      }
+    },
+    "OtherTests": {
+      "D01": "Marking",
+      "NonDestructiveTests": {
+        "D02": {
+          "Key": "Visual En 10219-1",
+          "Value": "100",
+          "Unit": "%",
+          "Interpretation": "Positive",
+          "Type": "number"
+        },
+        "D03": {
+          "Key": "Non destructive test EN ISO 10893-2",
+          "Value": "100",
+          "Unit": "%",
+          "Interpretation": "Positive",
+          "Type": "number"
+        },
+        "D04": {
+          "Key": "Dimensional Inspection EN 10219-2",
+          "Value": "1",
+          "Unit": "Lot",
+          "Interpretation": "Positive",
+          "Type": "number"
+        }
+      },
+      "OtherProductTests": {
+        "D51": {
+          "Key": "Tensile flattening test",
+          "Value": "100",
+          "Unit": "%",
+          "Interpretation": "Positive",
+          "Type": "number"
+        }
+      }
+    },
+    "Validation": {
+      "Z01": "We hereby certify, that the material described above has been tested and complies with the terms of the order. This certificate has been created by a data processing system and does not contain a personal signature but the name and the offical address of the appointet department.",
+      "Z02": "2018-10-23",
+      "Z03": {
+        "Name": "John D. Keller",
+        "Title": "Quality Manager",
+        "StampImage": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIwAAACMCAMAAACZHrEMAAABaFBMVEX////+/v78/PwAAAD6+/rv7+/k5OTb29vn6Of39/f19fXV1dXy8vLs7OzT09Pq6urh4eHe397Y2NjR0tHm5ubx8fH5+fnj4+PMzMzu7u7a2trExMSkpKS+v77d3d22tra6urrJycn09PSwsLC4uLjCw8K0tbTo6emfn5+urq6qq6ubm5uoqang4ODX19fOzs6dnZ3Q0NCYmZnIycimpqbPz8/Hx8ehoaGBgYGVlZSTk5PLy8uLjIzBwcFnZ2eWl5bGxsaRkpGGhoa9vb2zs7ONjo1iYmJ6e3rAwMC8vLyPj4+DhIN1dnV8fXxvb2+ysrKtra2IiYhqampTU1NeX15+f35sbWxYWFhkZGRJSkmsrKxQUFBNTUxFRUU5OjonJyd4eXlzc3M9Pj0aGxqKiolwcXFaW1tVVlbk5uLh497r7egtLi1CQkI2NjYREhHm6OMqKyo/QD8zMzMjJCMfIB/X2NMVFhUICwvMzGXBAAAdpklEQVR42uyX+XfSQBDHvzuzAZKQkoT7voUWkEIRsBREaau1rbWtWu+rHj94PPV5/PvSYLWez6vqD37fW95mmc18MjNvsoHAP6N/COW//uuPSwhBByQE/o7GFOLLy/Rnkd77IzVa04f9/pmxihG3x0sfQP+IiJzfqH96aXCDP9GVbqtdUx2gw+cRBIDCo6W7PNaD9RMzQ//UVKyWqll6JHn+xNpjHmt9MaVOsA9PDom0Z28wP9ks6GHL9meLo/TG1SOZRHUmn86vZP12yo7PX2F+efxYDsBhhcdBCbeeMZ/uW+56MZnJp9sxl88rJUAkZa5k6cP0dL4wZ6faF5m5kjocHAdFLQ6Y7zUs/5n84tCtyP2/IHFAWi2bqRb8drzLvJWVh4BDgDZ6xFcKlp3MF00VewrlAFnwwbulQEBAyXesSauRVn8mX3cXxjviezi/NSwClGRe8499xD0OXCAE/y3uCHGXddyt7Znou5VZdvkGlRULAMKZxBlruM03hgQhfmdY9B2+449tnHcTADXSuc0x+WLFz/NY2OXWtg0CbmSAHOae+hPrpLgASH+1YLWv8c4UQL8NJbrAD/VYZ7oEAK7567x5ltPm3SAyHEpULeYpELBcBYAWt0pAgs/1BIBUIm3GX/I9H0C/hyXJPHLlWz4AocUjN1a5jhLf07j66vp9LK7D2KmDBFxPb6+epJ3ESg/a9XaGqxAA3OW0K808+g00QqC0xqvhXscEFAMnHw2mcKoFusM+6+Gb9RwUEyAJQEDrFxSDL2/YyPP94eA6rLMEoH7cb17i2z6Q+NWwxJl7VjMOAMlt3AoASLEXM5wC5RwLsTcwGRBBPVE2OHmW11LYui1GBkCFTmDE3ADEL7HIWb4c7s8qQCmjYKudbCITxXIR3tx+2Gk/hh86nHYUkkuw2XBfWjFVwLWUtR7zeYB+gcVY5pav3AZSnhxzd8C5wvNHHqghwOks0kuEgDQskgD5ou/OEAAhE8YdXrsGjZ1ekE/4TvKmCvpplhRzI7XkgkSWceZu/DQvISwh3gWCcLRJsWwDetXoKW2z64Y4EC05qCvnx20H7iNRwN4MrPADBfSTLHVmV3xegiBwtotlN8LHxCQkjgTsOUzV05p2VLHNWbrkP1AUYmI2u4s839m1geDCUZ1feH6KRqDP2778IjCpz0GktjBx8hEwJFxekBCCYBif3cM4FTK4CpPDAJorKWbzJ2gIQx4o1TomSSE0tiEE0XjsXZHA3tRJ1j6gcCbOkhhr/3g1w92tgOWBBFrnzZ+hIczxOV/ZgkxhsjkQ/ea3qID4yo2sRTQ3nalApmwxB0A/yGLzmlF2AV6uABR2PKmaSV4jo1pt9ZiJbMYz3cuRpxUMkkuFQG0UtatKWJVaIZszNHLNjdQP0NGZCwpQrKT42Y9VMcHFF6LlEtTThsJNLNxycmNNnb200TglO8vFe55UUg2VLTPWSVYS5+ZLIGwshPKrWLqdUTuBY3q9ra/qTurGonb30s42ASgmUryjgn6AJbj7zNeswRiMIJTXfNPnpMHq6Yk7MpFZHMqtiGvaRE9NTVWPTPerD70QFOHF6Ytqv7cje1LPRdZxPyn36/jp7mZlFuQD0hs6d7+/FwvQZfZ0dGCefQ/csNeCkyfRFIKi+r0ScEdQa0OTIaHMUQg5AshjeQ07J+GVIZJQo4hltf3aVpHnCEx2A1eLQy7/AEyFY4U4VEtb5hV50/1pF//srEQHlw5MDm60WQEecBCY11s8An1nkpKcqVeBi0dgPDl9bfqDI+GEzXHiFBGCBlSXBIL0DpI+0IjJy9xHkwtPFji+dZq9kF3XRXaDvovF5E2rCXRWpY3QlcJX8ytQazbQWipDr7QQMRuNg5YOl5ZZuyreGUM7d1lSWgV88yW+qUF8R47kW8qshC2NJIi+6TcDzAwgh9wonsih8cb7wnjEqPHA+0o0UTRGc+fvrz39ia5xs7v1CdjCdD1fVb2qHjYZG7EQp/02HhkEtD9o0ZaFvvUpzFWLrubt03aIeyDOL+7i/KhHLtWjoxUA1voAO+/m1H8AI5BjaD8JYaxyBqdZKOI1ZdAemYD9QkPKbrzzmkXC1xWAVkse3TNbOcx6nWtVQakYj9ywHXgZz7Ab4l+x2MyHX8I694nK0UH+P0X2IU1UB0Cif3Sex80aICSWiNDQXoYQcE9yJsEgMOeqMALtXzY1Tw9jI8DqWwB9S1DK6/X6PNKMu9c6I3Jn3geLRHTpEUKo+g/qKL1KcV1BAdCwDkwzLVet9C3E6nyAKxei3P3PxHQyWYhhhnuhh3/ZZYfiqek7C7+ITzQ1zM7ONiwuNtzbYpMMjwpnXal8npbXdJ/XyjrDV2ggp51JZK5HRBw/baVW2hB/JKaDxXAevj1vOwuy9/6PW7i+pnLlhrstcpFgh3IkkCdfoJVsdMDoK4bDl4aR4JcL8SduBEYZmIpC8wKuiqtWHPd3y+Sr9ozJPfPvCt0VchA6NKy0QkDtWODPejTwTHYUxaCq+8bCIF9B/FFiMqkxpIfgxf+04RkA+2RQOuqvPFbQPXmWOI/eV7hQ9YVcSCqg9s9clxnIwf3ZSLMonr2Lpz0g1x60TWDsBtBRVKOT+VU+15jZ0DHD1w4x93TZB0F4in7mIf5ATFODHxMLmdN6Sesf+pFc6KZpCqX72OdUERgn66FjqFjzIVBkGdoy5Z/UmB7asCPkFLDWO/zP1GhYYlca0Md3zHDlKStAR3s+nap1xvjc8sLK/Idxv0NS3UeuAev85gNi1ya0R2QPwdpkq/xUi1tHhuzpOeQC4Mv1sg3iH7B42JoKO++6vnc9QFbDbH1uYKzeiGgKi+f1+6XDHa4k33MrIv0Y9QBe8yQBTKYeeRCrnEXdCduho3eeCzrayHQrp6Bjzb/8VX+eGoE0G9NqG0ul20NWeDqLscfxHJBOyTdXt6OUk5XqA8P87ENqG+paZ143N+lHiLQBm/4Mm2WWB+RwI1A/EJevz4svp/yy1wX12sFZdTy9f2E5DIia8ESHTeiYIhtuL39ccx2aSqkFHlvii5IEqMw2TuhCt8wlg1uJLLMY5YHmKjpFPpDcW36WGYFB2p0GoI16oVQFjnXlTlebVfXUunWfXI6SY1fB23HeS6m2zT0M9NxjsVIxoEuSNcEjL3Jcu0pzEGWWa32wLcuO59BoeH8Q6oR47Nbs6E5Xjnq6AOPRNQKzo1Bgum+Dniw5B0XkBrfrfvmgqVCu7tKPQR5YeMNJeE84fXVxrWOB6XsXImczC/EMFi9bG2w4kTBCqf1sfvni9Ho7Z+sAkixBPDonnkq1n+NZuBq8nSa/WArAJCfXGYRQ28VDXMYiVwVyLCPFzcsZupyMrslzW3z5QHsuSimG0iYE4H/7aWe7eMiXIZcFaZ4+0vO4ulDnlZrPbz+qwWr45oYBBWaXJNMKzMKptch55DkHLDF395hc2akDvEe1SUZDINP+3AlTw/B86A10eN8dLRoaYl837lUXMfKo5W8jpfPzgR9/3F5W7ZMz+iFqYI5MWYBhjkYKTGOGA9AWmMU2P74E4G07YOjBfWfymThpsJiZSAKJk4Jc15FlKPV3OFj9XY71c35xVy+r/u9nHFNg5lmZJPvlYplrV3J+kjjMClPYYBnQkYp/Yf3DnZPF3tWNZ6Lkp503gYM1QMjG4HQTZfo8y4/zVzET3eTe5R0zvfwu1UJ9brxELss4koOtdMM65zSMY/rRw22hoyub4EVNoDUE2zI0oP2ueHdRQsOJ/IgTmb5aZFuOqLqN6ri6+oi1x4PY7aWnnyeSeAnvgsORbzcMAjaPRi48kDVkI0gGMcSPPniH0csz772KAVba/9wwvPE2PAZMOukn5PW5GhjfCVuhq5WO6eslhxzjIzddd2Am+F2mtwR9zRXMkUVgkVywoKNANiJHJqztT5xrP3RZk6PtNWaEQD7JAsRv8vumPYDoN1nCmkCSHKqB8ZDt6uLAQjy4e8ZmpxudcPe2enmVJQ9NB4z3mnPw8+x7Ak08lliSFyc0rE/81ZH2JW9IN7xWzWfSJ2cP/9u3T+cDBBhusxBlgwrFIPkwrDXKXUqvBHrI8r51wDUHzGe+67gD06nSS4L5whGnpDIoca8FiPY085ueDU+SzUAkGXVovx912lYLQGAwzSfNUmCC7jZoqAzLGEXRTqe7C+fE2stv3jSZh3F4Q5/5lVkJxnfG8lXs8mqEfKOyOnLMESdCh5LZeqBoJ8idfQRn4qp5PflKY2sfXv80O56CyV27U9Dxit0w5gQyZJPyIKnkZGdphh8gKlxHvQyacII3mojFqtukS9HpcWYm6/iGzfov9qCzAAxwRmhQ50BREylNOfWdWDCDT08JGpa37LCk4jWHj8eAjJKL9q3XCWBROpnhrmYeMI8XZBxKCnuuLm9/fOL9jceYk7toJS+Qp1xoQMR5Uw0C+p0BOu7NvJYF9/tcfpRLhRzE9n6jM0ayGyjshXluyo1jWOGGLKB+pEg3hJNJ6atL2SfrkVnocKSKe2EDLcc/mcJYq19JAOr86DfsgbA7Oqi/KMGX6R7zW6qXftUB8SkN8aSYZl/FnGvVODVE2hhj5nabGRR5rot5Dss4hNDGXx4l+MxfXVYnmULSiY9xwK8bIy4gxc9y/ISm+omrL+5ODZb6W41m3TQQKmRTRb8jFfNO+z2aegImwuaMUkLZjJy6CYhj9le3+AEjXJESl4NNBrDGQ0uCSclBzygwA/iOmYRnvdVtKPHoI3ctx53CY8ILmF2IOanaaMLxbpRlWkbF5Aq0v4Ex2PzGUpOis8U6mShx70f1NQ/1Mqfg+8xZpPgpgSGuahJME9nkmWJJBtfngaY/2nGA3K1TR9SwZcL0iYgWRYsuNOgJTFtCj80WRoISeNJ+P/9EZurob4tC1LrgFn9GxjkZrJa5ab3jPoKkG1numJjhOEpR4D1ZWZ6qg8KvTHgD/vaXLYD/gkwHTIHsh65elEYHUyhZs13uOcM+arHR6MkP206lI9i/dK091bxkr9DgmppJh9XM9tUzz+FqdZgbVoVN6OaR12l2GGdbIIuOkbPxWXdL7XgfrbPbelY2r7/sjjQLyf70+vGvIaBr0ewV9YHES807mJ+AnTReRAFdlpeKQbBp9Gf07/NJTFYI4t/6rQnuA/oOTxuPOHV7+YF95ieOIcO38LxjGRjl6lJUa4tbD19kp3o2SO4svWpMRIHaNG4K6UR1tYQuopZRe1M9KzAjv4N5AdR99CHHEzbir3augztxIwh/7EqoFxBF9A4ugKnG2Ljj3s/n3OXSzokvPXnp+fvRSoazMZfEKS95LxkbtGil3W9nZ2dmd1ZSP6RvBz6kSTF+Se0wpXHn/Cw/y3oIxpOnoZGuiJjZ5afMoRqsRuXXk+AH09/X/Ug8fjDvdgRmnU6AEakNrKeQpT98QFPgv6JPQ185/tEC/SgSYE7nFk3OpN6nF9y46Hw8c/SFA+S0qsRGNd22loy8nnFUgdx1Eb2fIzDb81+Q+2B42ob0Mo9Z+v531GJj50n+HVr4PEWrzMHPo0ppwliQ3XZ7QH52gFwd1PL3+MHVSOYiGL8+aWc3q0ZvPmuw7leaiLf9fl2CVmf1Zl6uqocz5xwHgnqq9TYwMbRXEToCU2t0icDPph8n9CzWoCpa9AcVUqmGWxJXBx9QSl8NBXnE+jHTY5nYbjqMYgabtqS9jHLBgmvxpHde5OyqhvgsOMTer+drp6IqpViELXH47gMPeBbiFRtW1VUO0Jkx3KC9zz/KIXeVMsdTREkpXDMZaXRjb1gth9AvYsHG+mZUet7L12bhQ+L4nSeLXb0sQRiy2oSdkvlklvcmJfbV2qQP/P485FcyyGhR5R0JqH54PITv9T4hSZl5m7HkTJA8jkAWmQyZRDYkV1DCPLhA7R3kVnFj58W3KnLw2uRxVtKaxVyzsaoFX9UMqDn/x6UjI8/nQJBV1o4woWhO94CXCojb+b5Tdz0Q/trYQoCLJ99jfVgSMTpFkOmRbuygygdf8ZYQ1fV1BcheCBBD6C7PxQrzmVjvMIC0iVg6ZNgXc1pyJ4fI7FJTbi3bWhkEw/j7vftWm2D9Q4LcmhvR46DfegUYLzdVCo5KpRcbxhiJx8EWtq0hIKfwgmsl+eswxje+Jhf3iCaz5uI0OwmmTPPA1hYYxehbnBdnvC0muMOQ5GLe8L2zRF6PwVK76yZXxwLsALfZ9PbGuf8eTfs5JsDXsejCJBjLja/uPNs3zcxHLXI3PNs+pfT9TghvJOl1jJIV/6gQsdTJUf+kzIS8iWCwv/dyxgRILS4ERaa/Nj52RDaRd3VIWphCZsQnQoKMCBCRAyo0IS38OsVdEuIhoDKXofIkmDw952WQ8Uqmyod51d3EQ5fjgGub1bBDvJPhkfsrFuM5krUtciXp5YytpyRIYS+LfbPjdGLlyD5YxflP8ICebilxTyLIGCfvyMpcxUPn+9VYb13N8vywGF5IPDJKnLV3WyCTZ6sf1jN3zrJkm9LZMHAbXouKjD3gOPhGBOK3u4r/rvhUmLoJEhDIOWZynBTzupzkVGLLEBsPwehU793Dwg1oPwaMh3HDdKW0p95ZA1jZV5KD2c0wyG3Q2FPnbMJqzBkuFvmVifjS9EVNH/iq5cnvpHXKlsenWWE/fCWMoYAgUAZrb6YBcm91eE6G1Rrf59a/YQIrBc7FLl1twXx39U0LrNZ+54dpQJ+/bK6AvI74d3xjKOxMS3YhfXVP9Am22SAc5O82y38OrVGCV1bryC8uZcjroibUm/7uDnwPz59RpQDfuNPijC2vGXMWZOWRD/X7chWYZbwYSHfBFOTEjsNjz14sd43NA/+b9E8kqbDVwodgonR1aIB4KyJfiIhInCRxt5krHfewWWTS8dochDsu8iTuaEnleSeJ23L0K1vdOxMAGPI0BijZMuWnwrzcW9jwmhB5Lt5ngDYANIKFTU0d+a7up6OCg7Q3lmnGpreO5j1dQMBfruY/Xq9AyGOtPg3MefDjpWlYCIq0mfRSne7EIN+M2afPuwZ9sbsM1BK5A88WDv3gIN+YI4DsfyaH9QUmdK+GOO6hP8PJSx+mI8mdJenham/Dol5VD7I0OiwHWF/7ixMjZqvVW26+fUEP88tRtGmymnHH8moTgLATusMXnLWB2QMg87SnJlqI94Ene0GxjlYKRJ1ofml1nkpvGPRX7yruyosueTYbktvRkX4TLbuqLO5A3xVbVMemO/PPFWHo1SIH3tWDxOB82F8Bhz0Bc1RXtVdW5Kih9t+rBQRYJ+CDMYzsves1YV6gdzTFpOXOJR8Em3nrOgA0N0UEfIidm7wILLgmfHhQSlgqkNvi3fuX8iAGS2VbMXMQFH1yTyG12ajOstWMoE7WVy8U37zpiXy4lMvCFw5pXMUvimJFmJk7vKE91R+qVLSoJoYMnte0qAGfERJDmmjEeMMv+p206FDUORh+J6mlQ7wpGA5phsY7t1RCIcO5I+oPhfwOhdJ1RakQzMS/3fPaPl2ElaQEzdQ4I8ruEkOmcVJg6aj7d0sGxzmV+p2i2Tl28D5OuuJeILLzZtS5xfk4N4dElmeaowIC6bQgopbM0fp0xnhzhMOVEu7R7OPMcAzTaHqN88Fnz3/NoM/S+owM8CSd4K2oKKrZ4u0ePEmKVaDIXIT9xjQbTGBp0kolhf0Q212zajF5kgE1iNU6yIOrhd4K1SdgTrhYFytlIBjZHijl1May/44WDwlIBnyChDcSn+VQmcNsmwQi6HbUmsp3FSAVHD4wzPBhOfDO89/wdehCx2BalSfNGMgdFiCiQlOR1sCU6yj0f1uJyyxIYSenwuVNIspglNdk00dqsqaOx/ToiFwm4YVX3swa7t3LYNJbyACJcBHO1BVddz963TL9ejrIUoIeFJR4sB7X6/bBCq8ElZCsCFK8pAdlwwAnOVdZll4PKoKlC0rQ+elRUPEOvsimSCcmb9OCK8V9GwRuI1jfj8hJjRgCNQ1DiIRiUsXHOcQjLHEcITIhEg+pEhlLiHfLHX6E87fmPKk06G9tOvXhhgbmtTHk6ara6kFfz7e44MAXJ8BS8Vi3AuBXAD7lS791G76dEtQil34vo5lUaGEalkkLdR3Y9EBYJ+b00Ko06EYWfC9D5nFsZZ+g0Gung20l3BCBdka44seTyMktCyeHpuLTAOlI/OAZge83/fUcHS4OQcD5dhtrMfimgImYnE+C38+lVbnOwX0ERBV9hgFSiUDNixKDIp3V4LvXBrv87c9aPwEsCw0aBfkdk7x1qmfq8N3Ig9hOeoobNrpw+qaNvJJdnC8D6J5cTCyP3VxAv3x25EOmtEgzU7BMa/czavY09PsvUzhITdkskpW8pTL+YAWEjDMIELGyliFVSir4s6Oze4BZcMSRpvyRBnsuTZd+78QqRJ/6WwSH7/oRZ7Py+xzQ+jZcndyeX2veCzATu6BwiCV0H5TNvoUIh7ukhBboNgCz4f99ewZvZZ1umi2WyG8dUe3uZv6IUFnfdtkRPNzcVu9t5Kzt+4HKxkIY2L48z5OSwtyWscCU04BxbIC/MT5hQaHfP+mkhXofED8oIzAojV1ezZ8OWxYYtd7fjt4bvBEroCqmlw68oxO7WoFLnERccaZra40YwA38W8wmPWKlokdLuSTSXaBw8uSFV2vNCsgI5MLlQkh53uCAe32k8ubMzWl/LgpjfU4WtkrhtN1OHWTKZ4UKYFRJZ/bp7j64Q9Mp+xFYWCU31G5XAWzQLbUgu32X4ICckqZ0Zob2j9cz93udsw9+/DH9WXO3/MlQOb/sJwopx2yIfMR9DOvdo7xKdYAs186pOz17DBryktqJAsJ0I5lC8aM4IAJyNoBARpXOY1yhd2Pf1fpIWOJnn3620imbh7YWud8y7lkOQDnMZhKzdAaPAwMCskS7uSS6b0cRoAuvUgAC695WQBVTiE+125lqquIBkGNms1tS3EVzfku7nIFdBuQrB8v8Y7EAhG2nyHXnETjl+p9sqvl9EyrHTiOfNgP+qOdmOt8OMdfS8CtKPRqLCYqSayp6mlcjnOuHqR/ZCNCfLk3EbsS5x2Px0HBX9CCwrCJIF5qc/11uHAnhNfGWHCDeN0sYhlYReV6V5TtKWjkOn7y1CiPLI90Q12lvhOXRvDmkSaNhIfiNjWuFnQDI739cmemCCzpEnNYBYL8qHtPyH8Pi1jtHT8VhAZy2SvPwEeh1eI7er9E4wBPQ7OVdGeTjJCB3EoGPvBjiHyOfG0ToKq0A+GXXRzwxFjXAc8h/61Hh0NLaVzm2bA1FQrwhlOjXAZA/9Vhp+Jr2zRdnBAsW4MgzLWIGKnEbTx4WPcJYOzqzaPzlOaTnTOtmitEBXeInsTxecM7pB019ZoOl34qK9Mlcx36yLpvqKH/slY5DXolcmrYl39olrQIiB2uuvkJp0c3+k2gQeEa30u0ZBRCwo8/TcH8HCt1NRLctdbJ7xADQ2X1hnM5YmDuUr00gXd0IbtFPzD+NxesqUnbaJR50BMBG6QnIXvFgSaFfNlpi/dlhYDBImjW0nq2Qp8HgJsS3ALRONT8/CyA+ty+cU3oeGUH588wxDulPiVCqpwNyWFzqn6ToxzMfD4z803gpVqTxVHn2auH7xC69voD2fUUTS5f9DhCpF1JCkdLDEED+wsejhVf07UQglUwZQLzKI8bJl2dhqw8gOkBueBVHf7PV+YaqWPzk/aSsAVqunAs6TD1J/6WPSXvbR07p1y+C1rCXkMHION0rSU8bjYjwFkrJ9rdJqp2vcgMRUGUg3C1krdw6pXuK25q/lFhx9SVKj1NBu1DNBFUAsoZwtQQjg2AW2SsdmuFZSX/ibNvSyx9Tup4eQfnr4RjlS0qXsno9McykbDMsT15jpLurqawdbw5fUbq2Gv57oIx0vC9QfYfS3U6iqVvtbKZYTKVyi6W2vZjLrWaL26WFrm0X2RsHns2G/uYXIHgBFjG1Rx26nskkbKterytWc8FSFEuxFrONXSfni51FbYT+byWvrZKZaJx+QBl9/93l87Xd3be/oC5dv2iKZIzk76dRSIHj/cr+3MzgaOn4ydXW8ouS4ucj4yv+JnrU+0t8/9DLVm4fYRmv3rDk/y9B+p/+w/QvEn/fLzXefE4DvELvAAAAAElFTkSuQmCC"
+      },
+      "SupplementaryInformation": {
+        "Z05": {
+          "Key": "Quality Department Tel.",
+          "Value": "+43 732 1000 8888",
+          "Type": "phone"
+        },
+        "Z06": {
+          "Key": "Quality Department Fax",
+          "Value": "+43 732 1000 8889",
+          "Type": "phone"
+        },
+        "Z07": {
+          "Key": "Quality Department Email",
+          "Value": "quality@steelmill.se",
+          "Type": "email"
+        }
+      }
+    }
+  }
+}

--- a/test/json2pdf.spec.js
+++ b/test/json2pdf.spec.js
@@ -24,7 +24,8 @@ describe('json2pdf.js command-line tool', () => {
       'test_certificatePath.pdf',
       'test_chinese.pdf',
       'test_custom_xslt.pdf',
-      'test_invalid_xslt.pdf'
+      'test_invalid_xslt.pdf',
+      'test_malformed_logo.pdf'
     ];
     testFiles.forEach(file => {
       const filePath = path.join(tmpDir, file);
@@ -224,6 +225,32 @@ describe('json2pdf.js command-line tool', () => {
       const errorMessage = error.stderr ? error.stderr.toString() : error.stdout.toString();
       expect(errorMessage).toContain('Error: XSLT file not found');
     }
+  });
+
+  test('should fail gracefully with malformed PNG logo (truncated image)', () => {
+    const inputFile = path.join(fixturesDir, 'EN10168/v0.5.0/malformed_logo.json');
+    const outputFile = path.join(tmpDir, 'test_malformed_logo.pdf');
+
+    if (fs.existsSync(outputFile)) {
+      fs.unlinkSync(outputFile);
+    }
+
+    expect(() => {
+      execSync(`node "${json2pdfScript}" "${inputFile}" "${outputFile}" --skip-validation`, { encoding: 'utf8', stdio: 'pipe' });
+    }).toThrow();
+
+    try {
+      execSync(`node "${json2pdfScript}" "${inputFile}" "${outputFile}" --skip-validation`, { encoding: 'utf8', stdio: 'pipe' });
+    } catch (error) {
+      const errorMessage = error.stderr ? error.stderr.toString() : error.stdout.toString();
+      // Should mention malformed/truncated PNG specifically
+      expect(errorMessage).toContain('malformed or truncated PNG');
+      // Should NOT leak internal Java class names or stack traces
+      expect(errorMessage).not.toContain('NullPointerException');
+    }
+
+    // PDF should not be created
+    expect(fs.existsSync(outputFile)).toBe(false);
   });
 
   test('should check for Maven build dependencies', () => {

--- a/ui/angular.json
+++ b/ui/angular.json
@@ -68,17 +68,6 @@
           "options": {
             "buildTarget": "ui:build"
           }
-        },
-        "test": {
-          "builder": "@angular-devkit/build-angular:karma",
-          "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
-            "tsConfig": "tsconfig.spec.json",
-            "inlineStyleLanguage": "scss",
-            "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.scss"],
-            "scripts": []
-          }
         }
       }
     }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,17 +8,17 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/animations": "19.2.20",
+        "@angular/animations": "19.2.21",
         "@angular/cdk": "19.2.19",
-        "@angular/common": "19.2.20",
-        "@angular/compiler": "19.2.20",
-        "@angular/core": "19.2.20",
-        "@angular/forms": "19.2.20",
+        "@angular/common": "19.2.21",
+        "@angular/compiler": "19.2.21",
+        "@angular/core": "19.2.21",
+        "@angular/forms": "19.2.21",
         "@angular/material": "19.2.19",
-        "@angular/platform-browser": "19.2.20",
-        "@angular/platform-browser-dynamic": "19.2.20",
-        "@angular/platform-server": "19.2.20",
-        "@angular/router": "19.2.20",
+        "@angular/platform-browser": "19.2.21",
+        "@angular/platform-browser-dynamic": "19.2.21",
+        "@angular/platform-server": "19.2.21",
+        "@angular/router": "19.2.21",
         "express": "4.22.1",
         "rxjs": "7.8.2",
         "tailwindcss": "3.4.3",
@@ -28,16 +28,9 @@
       "devDependencies": {
         "@angular-devkit/build-angular": "19.2.23",
         "@angular/cli": "19.2.23",
-        "@angular/compiler-cli": "19.2.20",
+        "@angular/compiler-cli": "19.2.21",
         "@types/express": "5.0.0",
-        "@types/jasmine": "5.1.7",
         "@types/node": "22.13.10",
-        "jasmine-core": "5.6.0",
-        "karma": "6.4.4",
-        "karma-chrome-launcher": "3.2.0",
-        "karma-coverage": "2.2.1",
-        "karma-jasmine": "5.1.0",
-        "karma-jasmine-html-reporter": "2.1.0",
         "typescript": "5.8.2"
       },
       "engines": {
@@ -330,9 +323,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.20.tgz",
-      "integrity": "sha512-TQ4OCazTRAge45FIp3bzO/chImObmasPzprgEzKSDckjGbshAWlYXeCe3U8YaGNaWnkzByyIRNV4P4aHe63M0w==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.21.tgz",
+      "integrity": "sha512-hZqLVGHauUCgw4rULF/IcjUcR+BpI3+7B/TVyvNEqvRplJg5e6LJJ9YKp3G+GyoAsGXNnFdLtENR2T6kQI7s9g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -341,8 +334,8 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
+        "@angular/common": "19.2.21",
+        "@angular/core": "19.2.21"
       }
     },
     "node_modules/@angular/build": {
@@ -481,9 +474,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.20.tgz",
-      "integrity": "sha512-1M3W3FjUUbVKXDMs+yQpBhnkD/pCe0Jn79rPE5W+EGWWxFoLSyGX+fhnRO5m4c9k66p3nvYrikWQ0ZzMv3M5tw==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.21.tgz",
+      "integrity": "sha512-L+X0AOc+8SN+1ys1/nzOlkdwB7FUz6ts3MKdWW6wIPSIB6LcDth+QcJzx+XbwZ+zfPFEQkKsRWjo/eF82JePcg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -492,14 +485,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.2.20",
+        "@angular/core": "19.2.21",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.20.tgz",
-      "integrity": "sha512-LvjE8W58EACgTFaAoqmNe7FRsbvoQ0GvCB/rmm6AEMWx/0W/JBvWkQTrOQlwpoeYOHcMZRGdmPcZoUDwU3JySQ==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.21.tgz",
+      "integrity": "sha512-lLWXzeLPk+4kkXKpy/h0OAie3V2YImpDrzluufJ0xR8OlCffJNpanfBjm7R4tOZB7i0ONIxhsD67Z0oRhEECCQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -509,9 +502,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.20.tgz",
-      "integrity": "sha512-tYYQk8AUz2sEkVl0a3uebduDUXPuKiGEKl2Jryrbn0xh9i1EsxoCjt1VvHnGnksGp3mz4DQihFVEnte0KeVQ5g==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.21.tgz",
+      "integrity": "sha512-eAs+krq6McyuoySyC0tbYuY+rtovdtmyNUAgxGANPYJMdkTYHcHdF0HVbbaxUpFDvRC6rV9NDpZUazgykLZoYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -533,7 +526,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.2.20",
+        "@angular/compiler": "19.2.21",
         "typescript": ">=5.5 <5.9"
       }
     },
@@ -586,9 +579,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.20.tgz",
-      "integrity": "sha512-pxzQh8ouqfE57lJlXjIzXFuRETwkfMVwS+NFCfv2yh01Qtx+vymO8ZClcJMgLPfBYinhBYX+hrRYVSa1nzlkRQ==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.21.tgz",
+      "integrity": "sha512-jdOEwkvUyF7VdJMURXkSB1yQy595wt1lSfSgUux9tZftA7UwamCsMdidUsKqRbdaI9M3r+RdIM7qrDAWwqzz+A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -602,9 +595,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.20.tgz",
-      "integrity": "sha512-agi7InbMzop1jrud6L7SlNwnZk3iNolORcFIwBQMvKxLkcJ+ttbSYuM0KAw56IundWHf4dL9GP4cSygm4kUeFA==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.21.tgz",
+      "integrity": "sha512-2r5V8JyInrmpLhBDKCmF2ELWUXxEVxyIm5wDqD7RxWnuGtEr08QlJmiuyqM58xWFmcaSx7s2c62OdCqAAUSQGg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -613,9 +606,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20",
-        "@angular/platform-browser": "19.2.20",
+        "@angular/common": "19.2.21",
+        "@angular/core": "19.2.21",
+        "@angular/platform-browser": "19.2.21",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -637,9 +630,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.20.tgz",
-      "integrity": "sha512-O9ZoQKILPC1T2c64OASS75XlOLBxY81m5AAgsBKhwiFWq+V28RsO0cnwpi1YSh/z4ryH8Fe7IUFz8jGrsJi3hQ==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.21.tgz",
+      "integrity": "sha512-v5KhTTK9FWaYmo6auXftQx1ll+9kbDhD44v68CFaIgDQG82ZihWatcdeKmPrA6dmoRXzyyNWIVSk1cNRCPKZRg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -648,9 +641,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.2.20",
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20"
+        "@angular/animations": "19.2.21",
+        "@angular/common": "19.2.21",
+        "@angular/core": "19.2.21"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -659,9 +652,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.20.tgz",
-      "integrity": "sha512-bNuykQy/MrDeARqvDPf6bqx+m1Qqanep7FhDy9QYWxfqz7D++/phqT9l8Ubj88juFCSDfR5ktUWdpnDz3/BCfA==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.2.21.tgz",
+      "integrity": "sha512-+jOSCdZ3sPiPS28Cu/82aYmJFo3HfEIPyRCEwcStzKiASzbqNsdQzn3lIoZCKsD6qdP4uPU7m/KelJNOKDzfDQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -670,16 +663,16 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/compiler": "19.2.20",
-        "@angular/core": "19.2.20",
-        "@angular/platform-browser": "19.2.20"
+        "@angular/common": "19.2.21",
+        "@angular/compiler": "19.2.21",
+        "@angular/core": "19.2.21",
+        "@angular/platform-browser": "19.2.21"
       }
     },
     "node_modules/@angular/platform-server": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-19.2.20.tgz",
-      "integrity": "sha512-fNiHhqJpKaYd4ABj/qMob2Re4zqXFKOIfV/wsgBL0QPX5bfjp9+sJQ8I39/zHuZtrqDGazW6MuTkOgSoUWGLYQ==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-19.2.21.tgz",
+      "integrity": "sha512-urk7XYX/C4HbE/ZeqcSXnAvbat8CdVXBF2oz0CiVY8V8ENYPi1OFRXbxnmGPtHo4YNWwcycomddcKcSNzRdE+A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0",
@@ -689,17 +682,17 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/compiler": "19.2.20",
-        "@angular/core": "19.2.20",
-        "@angular/platform-browser": "19.2.20",
+        "@angular/common": "19.2.21",
+        "@angular/compiler": "19.2.21",
+        "@angular/core": "19.2.21",
+        "@angular/platform-browser": "19.2.21",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/router": {
-      "version": "19.2.20",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.20.tgz",
-      "integrity": "sha512-y0fyKycxJHr82kxXKE50Vac5hPn5Kx3gw9CfqyEuwJ9VQzEixDljU+chrQK4Wods14jJn9Tt2ncNPGH1rLya3Q==",
+      "version": "19.2.21",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.21.tgz",
+      "integrity": "sha512-ktGPSjzWvSWMPtE8FyH9PTRZm0Qcjy+XOjAvGuj+Wdx4VBhdmEl4qa08Idd7MkWJH0n0LyPCupJdmcH0bsF1FA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -708,9 +701,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.2.20",
-        "@angular/core": "19.2.20",
-        "@angular/platform-browser": "19.2.20",
+        "@angular/common": "19.2.21",
+        "@angular/core": "19.2.21",
+        "@angular/platform-browser": "19.2.21",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -931,9 +924,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.7.tgz",
-      "integrity": "sha512-6Fqi8MtQ/PweQ9xvux65emkLQ83uB+qAVtfHkC9UodyHMIZdxNI01HjLCLUtybElp2KY2XNE0nOgyP1E1vXw9w==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -948,12 +941,13 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -1169,23 +1163,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2427,16 +2421,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
@@ -3310,9 +3294,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3417,14 +3401,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.1.tgz",
-      "integrity": "sha512-YrEi/ZPmgc+GfdO0esBF04qv8boK9Dg9WpRQw/+vM8Qt3nnVIJWIa8HwZ/LXVZ0DB11XUROM8El/7yYTJX+WtA==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+      "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -3439,15 +3423,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.1.tgz",
-      "integrity": "sha512-ooEPvSW/HQDivPDPZMibHGKZf/QS4WRir1czGZmXmp3MsQqLECZEpN0JobrD8iV9BzsuwdIv+PxtWX9WpPLsIA==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+      "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -3462,17 +3446,17 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.1.tgz",
-      "integrity": "sha512-3YaKhP8gXEKN+2O49GLNfNb5l2gbnCFHyAaybbA2JkkbQP3dpdef7WcUaHAulg/c5Dg4VncHsA3NWAUSZMR5KQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+      "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -3488,9 +3472,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.1.tgz",
-      "integrity": "sha512-XHkFKQ5GSH3uxm8c3ZYXVrexGdscpWKIcMWKFQpMpMJc8gA3AwOMBJXJlgpdJqmrhPyQXxaY9nbkNeYpacC0Og==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3505,15 +3489,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.1.tgz",
-      "integrity": "sha512-pqGHyWWzNck4jRfaGV39hkqpY5QjRUQ/nRbNT7FYbBa0xf4bDG+TE1Gt2KWZrSkrkZZDE3qZUjYMbjwSliX6pg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+      "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1"
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -3527,13 +3511,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.1.tgz",
-      "integrity": "sha512-vp+7ZzIB8v43G+GLXTS4oDUSQmhAsRz532QmmWBbdYA20s465JvwhkSFvX9cVTqRRAQg+vZ7zWDaIEh0lFe2gw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+      "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.1"
+        "@jsonjoy.com/fs-node-builtins": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -3547,13 +3531,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.1.tgz",
-      "integrity": "sha512-Ynct7ZJmfk6qoXDOKfpovNA36ITUx8rChLmRQtW08J73VOiuNsU8PB6d/Xs7fxJC2ohWR3a5AqyjmLojfrw5yw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+      "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -3568,14 +3552,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.1.tgz",
-      "integrity": "sha512-/oG8xBNFMbDXTq9J7vepSA1kerS5vpgd3p5QZSPd+nX59uwodGJftI51gDYyHRpP57P3WCQf7LHtBYPqwUg2Bg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+      "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -4462,38 +4446,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/@npmcli/git/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@npmcli/git/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
@@ -4541,54 +4499,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@npmcli/promise-spawn": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-8.0.3.tgz",
@@ -4597,32 +4507,6 @@
       "license": "ISC",
       "dependencies": {
         "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -4651,32 +4535,6 @@
         "node-gyp": "^11.0.0",
         "proc-log": "^5.0.0",
         "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@npmcli/run-script/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@npmcli/run-script/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -5528,13 +5386,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -5557,32 +5408,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@types/body-parser": {
@@ -5624,16 +5449,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/express-serve-static-core": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -5708,13 +5523,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/jasmine": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.7.tgz",
-      "integrity": "sha512-DVOfk9FaClQfNFpSfaML15jjB5cjffDMvjtph525sroR5BEAW2uKnTOYUTqTFuZFjNvH0T5XMIydvIctnUKufw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -6328,14 +6136,14 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.16.tgz",
-      "integrity": "sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -6367,13 +6175,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.7.tgz",
-      "integrity": "sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.7"
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -6407,20 +6215,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/base64id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^4.5.0 || >= 5.9"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6561,14 +6359,13 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -6584,9 +6381,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -6604,11 +6401,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6698,60 +6495,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -6802,9 +6551,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001779",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
-      "integrity": "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -7166,29 +6915,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
-      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.2",
-        "parseurl": "~1.3.3",
-        "utils-merge": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -7197,75 +6923,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/connect/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/connect/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -7350,9 +7007,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7369,24 +7026,6 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -7429,6 +7068,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
@@ -7522,23 +7168,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/custom-event": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/debug": {
@@ -7652,13 +7281,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/di": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -7682,19 +7304,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/dom-serialize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -7784,9 +7393,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.313",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7841,42 +7450,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/engine.io": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "@types/ws": "^8.5.12",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.7.2",
-        "cors": "~2.8.5",
-        "debug": "~4.4.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7885,22 +7462,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/ent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "punycode": "^1.4.1",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/entities": {
@@ -8228,13 +7789,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8415,17 +7969,10 @@
         "flat": "cli.js"
       }
     },
-    "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -8492,21 +8039,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
@@ -8519,13 +8051,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -8621,22 +8146,22 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8747,22 +8272,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -8840,13 +8349,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -9067,32 +8569,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -9139,18 +8615,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -9346,25 +8810,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -9408,25 +8853,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
     "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -9465,60 +8900,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -9534,13 +8915,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/jasmine-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
-      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -9652,16 +9026,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -9672,135 +9036,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/karma": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
-      "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "body-parser": "^1.19.0",
-        "braces": "^3.0.2",
-        "chokidar": "^3.5.1",
-        "connect": "^3.7.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.1",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "http-proxy": "^1.18.1",
-        "isbinaryfile": "^4.0.8",
-        "lodash": "^4.17.21",
-        "log4js": "^6.4.1",
-        "mime": "^2.5.2",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.5",
-        "qjobs": "^1.2.0",
-        "range-parser": "^1.2.1",
-        "rimraf": "^3.0.2",
-        "socket.io": "^4.7.2",
-        "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
-        "ua-parser-js": "^0.7.30",
-        "yargs": "^16.1.1"
-      },
-      "bin": {
-        "karma": "bin/karma"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/karma-chrome-launcher": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz",
-      "integrity": "sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which": "^1.2.1"
-      }
-    },
-    "node_modules/karma-coverage": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
-      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.1",
-        "istanbul-reports": "^3.0.5",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/karma-jasmine": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
-      "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jasmine-core": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "karma": "^6.0.0"
-      }
-    },
-    "node_modules/karma-jasmine-html-reporter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.1.0.tgz",
-      "integrity": "sha512-sPQE1+nlsn6Hwb5t+HHwyy0A1FNCVKuL1192b+XNauMYWThz2kweiBVW1DqloRpVvZIJkIoHVB7XRpK78n1xbQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "jasmine-core": "^4.0.0 || ^5.0.0",
-        "karma": "^6.0.0",
-        "karma-jasmine": "^5.0.0"
-      }
-    },
-    "node_modules/karma-jasmine/node_modules/jasmine-core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
-      "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz",
@@ -9809,201 +9044,6 @@
       "license": "MIT",
       "dependencies": {
         "source-map-support": "^0.5.5"
-      }
-    },
-    "node_modules/karma/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/karma/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/karma/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/karma/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/karma/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/karma/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/kind-of": {
@@ -10079,57 +9119,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/less/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/less/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/less/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/less/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/less/node_modules/source-map": {
@@ -10407,23 +9396,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10445,19 +9417,29 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "semver": "^7.5.3"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -10512,20 +9494,20 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.1.tgz",
-      "integrity": "sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -10601,16 +9583,15 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -10686,26 +9667,19 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
+        "node": ">=16 || 14 >=14.17"
+      },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -10750,11 +9724,11 @@
       }
     },
     "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -10859,19 +9833,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mrmime": {
@@ -11084,36 +10045,10 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
-    "node_modules/node-gyp/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/node-gyp/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -11323,16 +10258,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -11707,16 +10632,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -11795,12 +10710,14 @@
       }
     },
     "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -12167,23 +11084,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/qjobs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
-      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.9"
-      }
-    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -12262,6 +11162,15 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-cache/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -12360,9 +11269,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12515,23 +11424,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -12642,24 +11534,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -12729,9 +11603,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -12849,18 +11723,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/serialize-javascript": {
       "version": "7.0.5",
@@ -13039,13 +11901,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13174,50 +12036,6 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socket.io": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
-      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "base64id": "~2.0.0",
-        "cors": "~2.8.5",
-        "debug": "~4.4.1",
-        "engine.io": "~6.6.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~4.4.1",
-        "ws": "~8.18.3"
-      }
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/sockjs": {
@@ -13424,21 +12242,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/string_decoder": {
@@ -13733,9 +12536,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13879,29 +12682,19 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -14013,33 +12806,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
-      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
@@ -14128,16 +12894,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -14236,9 +12992,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14311,9 +13067,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -14337,16 +13093,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack": {
@@ -14770,16 +13516,19 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/wildcard": {
@@ -14933,17 +13682,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10756,9 +10756,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10775,7 +10775,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13064,35 +13064,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/watchpack": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,8 @@
   "overrides": {
     "serialize-javascript": "7.0.5",
     "tar": "7.5.11",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "postcss": "^8.5.10"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "19.2.23",

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,22 +8,21 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "watch": "ng build --watch --configuration development"
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "19.2.20",
+    "@angular/animations": "19.2.21",
     "@angular/cdk": "19.2.19",
-    "@angular/common": "19.2.20",
-    "@angular/compiler": "19.2.20",
-    "@angular/core": "19.2.20",
-    "@angular/forms": "19.2.20",
+    "@angular/common": "19.2.21",
+    "@angular/compiler": "19.2.21",
+    "@angular/core": "19.2.21",
+    "@angular/forms": "19.2.21",
     "@angular/material": "19.2.19",
-    "@angular/platform-browser": "19.2.20",
-    "@angular/platform-browser-dynamic": "19.2.20",
-    "@angular/platform-server": "19.2.20",
-    "@angular/router": "19.2.20",
+    "@angular/platform-browser": "19.2.21",
+    "@angular/platform-browser-dynamic": "19.2.21",
+    "@angular/platform-server": "19.2.21",
+    "@angular/router": "19.2.21",
     "express": "4.22.1",
     "rxjs": "7.8.2",
     "tailwindcss": "3.4.3",
@@ -31,23 +30,16 @@
     "zone.js": "0.15.0"
   },
   "overrides": {
-    "lodash": "4.17.21",
     "serialize-javascript": "7.0.5",
-    "tar": "7.5.11"
+    "tar": "7.5.11",
+    "vite": "^6.4.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "19.2.23",
     "@angular/cli": "19.2.23",
-    "@angular/compiler-cli": "19.2.20",
+    "@angular/compiler-cli": "19.2.21",
     "@types/express": "5.0.0",
-    "@types/jasmine": "5.1.7",
     "@types/node": "22.13.10",
-    "jasmine-core": "5.6.0",
-    "karma": "6.4.4",
-    "karma-chrome-launcher": "3.2.0",
-    "karma-coverage": "2.2.1",
-    "karma-jasmine": "5.1.0",
-    "karma-jasmine-html-reporter": "2.1.0",
     "typescript": "5.8.2"
   }
 }

--- a/ui/tsconfig.spec.json
+++ b/ui/tsconfig.spec.json
@@ -1,9 +1,0 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./out-tsc/spec",
-    "types": ["jasmine"]
-  },
-  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
-}


### PR DESCRIPTION
## Summary
- Bump Angular packages to 19.2.21 to fix SSRF vulnerability in `@angular/platform-server` (GHSA-45q2-gjvg-7973)
- Add `follow-redirects` ^1.16.0 override to fix auth header leak (GHSA-xxjr-mmjv-4gpg)
- Add `vite` ^6.4.2 override to fix arbitrary file read and path traversal (CVE-2026-39363, CVE-2026-39365)
- Add `postcss` ^8.5.10 override to fix GHSA-qx2v-qp2m-jg93
- Update `fast-xml-parser` override to ^5.7.0 to fix CDATA injection (GHSA-gh4j-gqv2-49f6)
- Update `log4j-core` to 2.25.4 to fix TLS config, log injection, and XmlLayout CVEs (GHSA-6hg6-v5c8-fphq, GHSA-445c-vh5m-36rj, GHSA-3pxv-7cmr-fjr4)
- Remove unused karma/jasmine test infrastructure (zero test files, no CI coverage), eliminating `lodash` and `follow-redirects` from the UI dependency tree entirely
- **Fix #269**: Malformed PNG in certificate (e.g. truncated company logo) no longer leaks a raw 500 with internal stack traces — returns a clean 400 with actionable message
- Add catch-all `RuntimeException` handler to `GlobalExceptionHandler` to prevent any unchecked exception from leaking internals
- Add specific error reporting for corrupt embedded PDF attachments in `EmbedManager`, including 1-based position and failure reason (invalid base64, corrupt PDF, S3 download failure)
- Fix CodeQL workflow: add JDK 21 setup for java-kotlin analysis

## Not addressed
- `uuid` — dev-only, no fix available upstream (sockjs → webpack-dev-server)

## Test plan
- [x] `ng build` succeeds in `ui/`
- [x] Root `npm audit` returns 0 vulnerabilities
- [x] `npx jest test/json2pdf.spec.js` — 12/12 pass (including malformed PNG test)
- [x] `mvn test` — 146/146 pass (including malformed embedded PDF test)
- [x] Grype scan passes (no medium+ vulnerabilities)
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)