### PR TITLE
feat(render): watermark test-mode renders via mode=test (#289)

### DIFF
--- a/schemas/CoA/v1.1.0/translations.json
+++ b/schemas/CoA/v1.1.0/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "Certificate": {
       "Customer": "Customer",
       "Receiver": "Certificate recipient",
@@ -57,6 +58,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "Certificate": {
       "Customer": "Kunde",
       "Receiver": "Zertifikatsempfänger",
@@ -114,6 +116,7 @@
     }
   },
   "CN": {
+    "WatermarkPreview": "预览 — 非有效证书",
     "Certificate": {
       "Customer": "客户",
       "Receiver": "证书收件人",
@@ -171,6 +174,7 @@
     }
   },
   "ES": {
+    "WatermarkPreview": "VISTA PREVIA — CERTIFICADO NO VÁLIDO",
     "Certificate": {
       "Customer": "Cliente",
       "Receiver": "Receptor de la certificado",
@@ -228,6 +232,7 @@
     }
   },
   "IT": {
+    "WatermarkPreview": "ANTEPRIMA — CERTIFICATO NON VALIDO",
     "Certificate": {
       "Customer": "Cliente",
       "Receiver": "Destinatario del certificato",
@@ -285,6 +290,7 @@
     }
   },
   "FR": {
+    "WatermarkPreview": "APERÇU — PAS UN CERTIFICAT VALIDE",
     "Certificate": {
       "Customer": "Client",
       "Receiver": "Réceptionnaire du certificat",
@@ -342,6 +348,7 @@
     }
   },
   "PL": {
+    "WatermarkPreview": "PODGLĄD — NIEWAŻNY CERTYFIKAT",
     "Certificate": {
       "Customer": "Klient",
       "Receiver": "Odbiorca certyfikatu",
@@ -399,6 +406,7 @@
     }
   },
   "TR": {
+    "WatermarkPreview": "ÖNİZLEME — GEÇERLİ BİR SERTİFİKA DEĞİLDİR",
     "Certificate": {
       "Customer": "Müşteri",
       "Receiver": "Sertifika alıcısı",

--- a/schemas/EN10168/v0.4.1/translations.json
+++ b/schemas/EN10168/v0.4.1/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "Certificate": {
       "A01": "Manufacturer's plant",
       "A02": "Type of inspection document",
@@ -102,6 +103,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "Certificate": {
       "A01": "Herstellerwerk",
       "A02": "Art der Prüfbescheinigung",
@@ -204,6 +206,7 @@
     }
   },
   "FR": {
+    "WatermarkPreview": "APERÇU — PAS UN CERTIFICAT VALIDE",
     "Certificate": {
       "A01": "Usine productrice",
       "A02": "Type de document de contrôle",
@@ -306,6 +309,7 @@
     }
   },
   "PL": {
+    "WatermarkPreview": "PODGLĄD — NIEWAŻNY CERTYFIKAT",
     "Certificate": {
       "A01": "Zakład produkcyjny",
       "A02": "Typ certyfikatu badania",

--- a/schemas/EN10168/v0.5.0/translations.json
+++ b/schemas/EN10168/v0.5.0/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "Certificate": {
       "A01": "Manufacturer's plant",
       "A02": "Type of inspection document",
@@ -109,6 +110,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "Certificate": {
       "A01": "Herstellerwerk",
       "A02": "Art der Prüfbescheinigung",
@@ -218,6 +220,7 @@
     }
   },
   "FR": {
+    "WatermarkPreview": "APERÇU — PAS UN CERTIFICAT VALIDE",
     "Certificate": {
       "A01": "Usine productrice",
       "A02": "Type de document de contrôle",
@@ -327,6 +330,7 @@
     }
   },
   "PL": {
+    "WatermarkPreview": "PODGLĄD — NIEWAŻNY CERTYFIKAT",
     "Certificate": {
       "A01": "Zakład produkcyjny",
       "A02": "Typ certyfikatu badania",

--- a/schemas/Forestry/v0.0.1/translations.json
+++ b/schemas/Forestry/v0.0.1/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "Languages": "Languages",
       "Id": "ID",
@@ -117,6 +118,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "Languages": "Sprachen",
       "Id": "DMP-ID",
@@ -233,6 +235,7 @@
     }
   },
   "CN": {
+    "WatermarkPreview": "预览 — 非有效证书",
     "DigitalMaterialPassport": {
       "Languages": "语言",
       "Id": "DMP标识",

--- a/schemas/ForestryOutput/v1.0.0/translations.json
+++ b/schemas/ForestryOutput/v1.0.0/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "Languages": "Languages",
       "Id": "ID",
@@ -122,6 +123,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "Languages": "Sprachen",
       "Id": "DMP-ID",
@@ -243,6 +245,7 @@
     }
   },
   "CN": {
+    "WatermarkPreview": "预览 — 非有效证书",
     "DigitalMaterialPassport": {
       "Languages": "语言",
       "Id": "DMP标识",

--- a/schemas/ForestrySource/v0.0.1/translations.json
+++ b/schemas/ForestrySource/v0.0.1/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "Languages": "Languages",
       "Id": "DMP ID",
@@ -112,6 +113,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "Languages": "Sprachen",
       "Id": "DMP-ID",
@@ -224,6 +226,7 @@
     }
   },
   "CN": {
+    "WatermarkPreview": "预览 — 非有效证书",
     "DigitalMaterialPassport": {
       "Languages": "语言",
       "Id": "DMP标识",

--- a/schemas/ForestrySource/v1.0.0/translations.json
+++ b/schemas/ForestrySource/v1.0.0/translations.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "Languages": "Languages",
       "Id": "DMP ID",
@@ -113,6 +114,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "Languages": "Sprachen",
       "Id": "DMP-ID",
@@ -226,6 +228,7 @@
     }
   },
   "CN": {
+    "WatermarkPreview": "预览 — 非有效证书",
     "DigitalMaterialPassport": {
       "Languages": "语言",
       "Id": "DMP标识",

--- a/schemas/Metals/v0.0.1/translation.json
+++ b/schemas/Metals/v0.0.1/translation.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "NumericResult": "Numeric Result",
       "BooleanResult": "Boolean Result",
@@ -225,6 +226,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "NumericResult": "Numerisches Ergebnis",
       "BooleanResult": "Boolesches Ergebnis",

--- a/schemas/Metals/v0.1.0/translation.json
+++ b/schemas/Metals/v0.1.0/translation.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "NumericResult": "Numeric Result",
       "BooleanResult": "Boolean Result",
@@ -362,6 +363,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "NumericResult": "Numerisches Ergebnis",
       "BooleanResult": "Boolesches Ergebnis",

--- a/schemas/Metals/v0.1.1/translation.json
+++ b/schemas/Metals/v0.1.1/translation.json
@@ -1,5 +1,6 @@
 {
   "EN": {
+    "WatermarkPreview": "PREVIEW — NOT A VALID CERTIFICATE",
     "DigitalMaterialPassport": {
       "NumericResult": "Numeric Result",
       "BooleanResult": "Boolean Result",
@@ -393,6 +394,7 @@
     }
   },
   "DE": {
+    "WatermarkPreview": "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT",
     "DigitalMaterialPassport": {
       "NumericResult": "Numerisches Ergebnis",
       "BooleanResult": "Boolesches Ergebnis",

--- a/src/main/java/com/materialidentity/schemaservice/PDFBuilder.java
+++ b/src/main/java/com/materialidentity/schemaservice/PDFBuilder.java
@@ -16,6 +16,7 @@ public class PDFBuilder {
     private AttachmentManager attachmentManager;
     private XsltTransformer xsltTransformer;
     private EmbedManager embedManager;
+    private WatermarkManager watermarkManager;
 
     public PDFBuilder(FoManager foManager) {
         this.foManager = foManager;
@@ -45,6 +46,11 @@ public class PDFBuilder {
         return this;
     }
 
+    public PDFBuilder withWatermark(WatermarkManager watermarkManager) {
+        this.watermarkManager = watermarkManager;
+        return this;
+    }
+
     public byte[] build() throws TransformerException, IOException, SAXException {
         byte[] pdf = generatePdf();
         return pdf;
@@ -65,6 +71,11 @@ public class PDFBuilder {
 
             if (embedManager != null) {
                 pdf = embedManager.embed(pdf);
+            }
+
+            // After embed so that merged/appended pages are stamped too (schema#181).
+            if (watermarkManager != null) {
+                pdf = watermarkManager.stamp(pdf);
             }
 
             if (attachmentManager != null) {

--- a/src/main/java/com/materialidentity/schemaservice/WatermarkManager.java
+++ b/src/main/java/com/materialidentity/schemaservice/WatermarkManager.java
@@ -1,0 +1,131 @@
+package com.materialidentity.schemaservice;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
+import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
+import org.apache.pdfbox.util.Matrix;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Stamps the test-mode preview watermark (material-identity/schema#181): diagonal,
+ * semi-transparent text on every page of the finished PDF. Runs as a post-render step in
+ * {@link PDFBuilder}, mirroring {@link AttachmentManager}/{@link EmbedManager}, so all certificate
+ * families are covered by one hook. The transparency overlay and the additionally embedded font
+ * make the output deliberately <b>not PDF/A</b> — a preview is explicitly not a valid certificate.
+ */
+public class WatermarkManager {
+
+    public static final String FALLBACK_TEXT_EN = "PREVIEW — NOT A VALID CERTIFICATE";
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final float ALPHA = 0.25f;
+    private static final float GRAY = 0.55f;
+    /** The text spans this fraction of the page diagonal. */
+    private static final float DIAGONAL_FRACTION = 0.8f;
+
+    private final String text;
+
+    public WatermarkManager(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Resolve the watermark text for the certificate's primary language from the family's
+     * translations file ({@code <LANG>.WatermarkPreview}; the pattern also matches Metals'
+     * singular {@code translation.json}). Falls back to the English block, then to the English
+     * constant — families without translations (Bluemint) must still watermark.
+     */
+    public static String resolveText(String translationFilePattern, String primaryLanguage) {
+        String lang = primaryLanguage.toUpperCase(Locale.ROOT);
+        // Broaden "translations*.json" to "translation*.json" so Metals' singular
+        // translation.json (unmatched by the render pipeline's pattern) is found too.
+        String pattern = translationFilePattern.replace("translations*", "translation*");
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            for (Resource resource : resolver.getResources("classpath*:" + pattern)) {
+                JsonNode tree;
+                try (InputStream is = resource.getInputStream()) {
+                    tree = objectMapper.readTree(is);
+                }
+                JsonNode text = tree.path(lang).path("WatermarkPreview");
+                if (text.isTextual()) {
+                    return text.asText();
+                }
+                JsonNode en = tree.path("EN").path("WatermarkPreview");
+                if (en.isTextual()) {
+                    return en.asText();
+                }
+            }
+        } catch (IOException e) {
+            // A missing or broken translations file must not fail the render; stamp the fallback.
+        }
+        return FALLBACK_TEXT_EN;
+    }
+
+    public byte[] stamp(byte[] pdf) throws IOException {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            PDType0Font font = PDType0Font.load(document, fontStream(text), true);
+            for (PDPage page : document.getPages()) {
+                stampPage(document, page, font);
+            }
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            document.save(output);
+            return output.toByteArray();
+        }
+    }
+
+    private void stampPage(PDDocument document, PDPage page, PDType0Font font) throws IOException {
+        PDRectangle box = page.getMediaBox();
+        float w = box.getWidth();
+        float h = box.getHeight();
+        float diagonal = (float) Math.hypot(w, h);
+        float unitWidth = font.getStringWidth(text) / 1000f; // glyph-space width at font size 1
+        float fontSize = DIAGONAL_FRACTION * diagonal / unitWidth;
+        float textWidth = unitWidth * fontSize;
+
+        try (PDPageContentStream cs = new PDPageContentStream(document, page,
+                PDPageContentStream.AppendMode.APPEND, true, true)) {
+            PDExtendedGraphicsState alpha = new PDExtendedGraphicsState();
+            alpha.setNonStrokingAlphaConstant(ALPHA);
+            cs.setGraphicsStateParameters(alpha);
+            cs.setNonStrokingColor(GRAY, GRAY, GRAY);
+            cs.beginText();
+            cs.setFont(font, fontSize);
+            // Baseline through the page center, rotated along the diagonal, centered lengthwise.
+            Matrix position = Matrix.getRotateInstance(Math.atan2(h, w), w / 2f, h / 2f);
+            position.concatenate(Matrix.getTranslateInstance(-textWidth / 2f, 0));
+            cs.setTextMatrix(position);
+            cs.showText(text);
+            cs.endText();
+        }
+    }
+
+    /** Noto Sans for Latin scripts; Noto Sans SC when the resolved text carries CJK glyphs. */
+    private InputStream fontStream(String text) {
+        String font = containsCjk(text) ? "fonts/NotoSansSC-Regular.ttf"
+                : "fonts/NotoSans-Regular.ttf";
+        InputStream is = getClass().getClassLoader().getResourceAsStream(font);
+        if (is == null) {
+            throw new IllegalStateException("Watermark font not on classpath: " + font);
+        }
+        return is;
+    }
+
+    private static boolean containsCjk(String text) {
+        return text.codePoints().anyMatch(cp -> cp >= 0x2E80 && cp <= 0x9FFF);
+    }
+}

--- a/src/main/java/com/materialidentity/schemaservice/config/EndpointParamConstants.java
+++ b/src/main/java/com/materialidentity/schemaservice/config/EndpointParamConstants.java
@@ -4,6 +4,7 @@ public final class EndpointParamConstants {
     // endpoint parameters constants
     public static final String JSON_FILENAME = "filename";
     public static final String ATTACH_JSON = "attachJson";
+    public static final String MODE = "mode";
 
     private EndpointParamConstants() {
     }

--- a/src/main/java/com/materialidentity/schemaservice/controller/SchemaController.java
+++ b/src/main/java/com/materialidentity/schemaservice/controller/SchemaController.java
@@ -37,11 +37,12 @@ public class SchemaController {
 
     @PostMapping("/render")
     @ResponseStatus(code = HttpStatus.OK)
-    @Operation(summary = "Render a JSON DMP as a PDF")
+    @Operation(summary = "Render a JSON DMP as a PDF. mode=test stamps a preview watermark on every page (non-PDF/A); mode=live (default) renders unchanged.")
     public ResponseEntity<byte[]> render(
             @RequestParam(value = EndpointParamConstants.ATTACH_JSON, defaultValue = "true") Boolean attachJson,
             @RequestParam(value = EndpointParamConstants.JSON_FILENAME, defaultValue = SchemaControllerConstants.DEFAULT_PDF_ATTACHMENT_CERT_FILE_NAME) String filename,
+            @RequestParam(value = EndpointParamConstants.MODE, defaultValue = "live") String mode,
             @RequestBody JsonNode dmp) throws TransformerException, IOException, SAXException {
-        return schemasService.renderPdf(attachJson, dmp, filename);
+        return schemasService.renderPdf(attachJson, dmp, filename, mode);
     }
 }

--- a/src/main/java/com/materialidentity/schemaservice/service/SchemasService.java
+++ b/src/main/java/com/materialidentity/schemaservice/service/SchemasService.java
@@ -10,6 +10,6 @@ import org.xml.sax.SAXException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public interface SchemasService {
-        ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate, String filename)
+        ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate, String filename, String mode)
                         throws IOException, TransformerException, SAXException;
 }

--- a/src/main/java/com/materialidentity/schemaservice/service/SchemasServiceImpl.java
+++ b/src/main/java/com/materialidentity/schemaservice/service/SchemasServiceImpl.java
@@ -33,6 +33,7 @@ import com.materialidentity.schemaservice.AttachmentManager;
 import com.materialidentity.schemaservice.EmbedManager;
 import com.materialidentity.schemaservice.PDFBuilder;
 import com.materialidentity.schemaservice.TranslationLoader;
+import com.materialidentity.schemaservice.WatermarkManager;
 import com.materialidentity.schemaservice.XsltTransformer;
 import com.materialidentity.schemaservice.config.SchemaControllerConstants;
 import com.materialidentity.schemaservice.config.SchemasAndVersions;
@@ -174,15 +175,16 @@ public class SchemasServiceImpl implements SchemasService {
     }
 
     @Override
-    public ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate, String filename)
+    public ResponseEntity<byte[]> renderPdf(Boolean attachJson, JsonNode certificate, String filename, String mode)
             throws IOException, TransformerException, SAXException {
+        boolean testMode = parseTestMode(mode);
         String[] languages = extractLanguages(certificate);
         String[] encodedData = extractPdfData(certificate);
         String[] dataFromS3 = extractPdfDataFromS3(certificate);
         String schemaType = extractCertificateType(certificate);
         String schemaVersion = extractCertificateVersion(certificate);
-        logger.info("Rendering certificate type: {}, version: {}, languages: {}, attachJson: {}, filename: {}", schemaType,
-                schemaVersion, languages, attachJson, filename);
+        logger.info("Rendering certificate type: {}, version: {}, languages: {}, attachJson: {}, filename: {}, mode: {}", schemaType,
+                schemaVersion, languages, attachJson, filename, mode);
 
         // TODO: throw error if language is not supported
         validateSchemaTypeAndVersion(schemaType, schemaVersion);
@@ -217,6 +219,13 @@ public class SchemasServiceImpl implements SchemasService {
             pdfBuilder.withEmbeddedPdf(new EmbedManager(encodedData, dataFromS3));
         }
 
+        // material-identity/schema#181: test-mode renders carry a preview watermark on every page,
+        // in the certificate's primary language. Deliberately non-PDF/A.
+        if (testMode) {
+            pdfBuilder.withWatermark(new WatermarkManager(
+                    WatermarkManager.resolveText(translationsPattern, languages[0])));
+        }
+
         byte[] pdfBytes = pdfBuilder.build();
 
         return ResponseEntity.ok()
@@ -225,6 +234,16 @@ public class SchemasServiceImpl implements SchemasService {
                                 SchemaControllerConstants.PDF_RENDERED_OUTPUT_FILE_NAME))
                 .contentType(MediaType.APPLICATION_PDF)
                 .body(pdfBytes);
+    }
+
+    /** Parse the render {@code mode} param (material-identity/schema#181): test | live only. */
+    private static boolean parseTestMode(String mode) {
+        return switch (mode) {
+            case "test" -> true;
+            case "live" -> false;
+            default -> throw new IllegalArgumentException(
+                    "Invalid mode: " + mode + ". Expected 'test' or 'live'");
+        };
     }
 
     private String deriveClasspathRootUri(Resource xsltResource, String xsltPath) {

--- a/src/test/java/com/materialidentity/schemaservice/RenderTest.java
+++ b/src/test/java/com/materialidentity/schemaservice/RenderTest.java
@@ -1,6 +1,7 @@
 package com.materialidentity.schemaservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -248,6 +249,98 @@ class RenderTest {
 					assertTrue(msg.contains("position 1"), "Should mention position: " + msg);
 					assertTrue(msg.contains("corrupt or not a valid PDF"), "Should mention corrupt PDF: " + msg);
 				});
+	}
+
+	// ---- render mode=test watermark (material-identity/schema#181, #289) ----
+
+	private static final String WATERMARK_DE = "VORSCHAU — KEIN GÜLTIGES ZERTIFIKAT";
+	private static final String WATERMARK_EN = "PREVIEW — NOT A VALID CERTIFICATE";
+
+	@Test
+	void testModeStampsWatermarkOnEveryPageInPrimaryLanguage() throws Exception {
+		// EN10168 valid_certificate_1 declares CertificateLanguages ["DE","EN"] — primary is DE.
+		String jsonContent = Files.readString(
+				Paths.get("test", "fixtures", "EN10168", "v0.5.0", "valid_certificate_1.json"));
+		byte[] pdf = renderWithMode(jsonContent, "test");
+		try (PDDocument doc = Loader.loadPDF(pdf)) {
+			PDFTextStripper stripper = new PDFTextStripper();
+			for (int page = 1; page <= doc.getNumberOfPages(); page++) {
+				stripper.setStartPage(page);
+				stripper.setEndPage(page);
+				assertTrue(containsWatermark(stripper.getText(doc), WATERMARK_DE),
+						"watermark missing on page " + page + "/" + doc.getNumberOfPages());
+			}
+		}
+	}
+
+	@Test
+	void testModeFallsBackToEnglishWhenFamilyHasNoTranslations() throws Exception {
+		// Bluemint ships no translations file at all — the English fallback must stamp.
+		String jsonContent = Files.readString(
+				Paths.get("test", "fixtures", "Bluemint", "v1.0.0", "valid_certificate_1.json"));
+		byte[] pdf = renderWithMode(jsonContent, "test");
+		try (PDDocument doc = Loader.loadPDF(pdf)) {
+			assertTrue(containsWatermark(new PDFTextStripper().getText(doc), WATERMARK_EN),
+					"English fallback watermark expected");
+		}
+	}
+
+	@Test
+	void liveAndDefaultModeRenderWithoutWatermark() throws Exception {
+		String jsonContent = Files.readString(
+				Paths.get("test", "fixtures", "EN10168", "v0.5.0", "valid_certificate_1.json"));
+		byte[] defaultPdf = renderWithMode(jsonContent, null);
+		byte[] livePdf = renderWithMode(jsonContent, "live");
+		try (PDDocument defaultDoc = Loader.loadPDF(defaultPdf);
+				PDDocument liveDoc = Loader.loadPDF(livePdf)) {
+			PDFTextStripper stripper = new PDFTextStripper();
+			assertFalse(containsWatermark(stripper.getText(defaultDoc), WATERMARK_DE),
+					"default render must not be watermarked");
+			assertFalse(containsWatermark(stripper.getText(liveDoc), WATERMARK_DE),
+					"mode=live render must not be watermarked");
+		}
+	}
+
+	@Test
+	void invalidModeReturnsBadRequest() throws Exception {
+		String jsonContent = Files.readString(
+				Paths.get("test", "fixtures", "EN10168", "v0.5.0", "valid_certificate_1.json"));
+		webClient
+				.post().uri(uriBuilder -> uriBuilder
+						.path("/api/render")
+						.queryParam("mode", "bogus")
+						.build())
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(jsonContent).exchange()
+				.expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+				.expectBody()
+				.jsonPath("$.message").value(message -> assertTrue(
+						((String) message).contains("Invalid mode"),
+						"Should mention invalid mode: " + message));
+	}
+
+	private byte[] renderWithMode(String jsonContent, String mode) {
+		return webClient
+				.post().uri(uriBuilder -> {
+					uriBuilder.path("/api/render");
+					if (mode != null) {
+						uriBuilder.queryParam("mode", mode);
+					}
+					return uriBuilder.build();
+				})
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(jsonContent).exchange()
+				.expectStatus().isOk()
+				.expectBody()
+				.returnResult().getResponseBody();
+	}
+
+	/**
+	 * PDFTextStripper fragments the rotated watermark into short positional runs, so matching is
+	 * whitespace-insensitive: both sides are compared with all whitespace removed.
+	 */
+	private static boolean containsWatermark(String extracted, String watermark) {
+		return extracted.replaceAll("\\s+", "").contains(watermark.replaceAll("\\s+", ""));
 	}
 
 	private void assertPdfContentEquals(byte[] expectedPdfContent, byte[] actualPdfContent,


### PR DESCRIPTION
Closes #289. Port of material-identity/schema#181 (sibling PR there: material-identity/schema#208 — same watermark drawing code, same contract).

## What

`POST /api/render` accepts **`mode`** (`test` | `live`, default `live`; invalid → 400). `mode=test` stamps a diagonal, semi-transparent watermark on every page via a new `WatermarkManager` step in `PDFBuilder` — mirroring `AttachmentManager`/`EmbedManager`, placed **after** embed so merged pages are stamped too. One hook covers all families.

## Text resolution

`WatermarkPreview` key added per language block of the git-tracked translation files (CoA incl. **machine-translated CN/ES/IT/TR — please review**, EN10168 ×2, Forestry ×3, Metals ×3 — the lookup broadens the pattern to catch Metals' singular `translation.json`), resolved for the certificate's primary language (`extractLanguages(...)[0]`), EN-block then EN-constant fallback. CJK stamps with NotoSansSC.

## Non-PDF/A caveat

Test-mode output is deliberately not PDF/A (transparency + extra font) — a preview is explicitly not a valid certificate. `mode=live`/default renders are unchanged — the golden reference-PDF suite passes untouched, which is itself the no-watermark regression proof.

## Verification

`mvn --batch-mode verify` green: full render suite + 4 new tests (DE-primary EN10168 gets the German watermark on every page; Bluemint exercises the EN fallback end-to-end; default/`live` unwatermarked; `mode=bogus` → 400 with message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)